### PR TITLE
Specify ABI handling for 8.7-A's new FPCR bits.

### DIFF
--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -220,6 +220,8 @@ Change History
 |            |                    | Extend the AAPCS64 to support SVE types and registers.           |
 |            |                    | Conform aapcs64 volatile bit-fields rules to C/C++.              |
 +------------+--------------------+------------------------------------------------------------------+
+| 2020Q3     | 1st October 2020   |                                                                  |
++------------+--------------------+------------------------------------------------------------------+
 
 References
 ^^^^^^^^^^
@@ -808,7 +810,9 @@ The FPSR is a status register that holds the cumulative exception bits of the fl
 
 The FPCR is used to control the behavior of the floating-point unit. It is a global register with the following properties.
 
-- The exception-control bits (8-12), rounding mode bits (22-23) and flush-to-zero bits (24) may be modified by calls to specific support functions that affect the global state of the application.
+- The exception-control bits (8-12), rounding mode bits (22-23), flush-to-zero bits (24), and the AH and FIZ bits (0-1) may be modified by calls to specific support functions that affect the global state of the application.
+
+- The NEP bit (bit 2) must be zero on entry to and return from a public interface.
 
 - All other bits are reserved and must not be modified. It is not defined whether the bits read as zero or one, or whether they are preserved across a public interface.
 


### PR DESCRIPTION
There are three new bits: AH, FIZ and NEP, in bits 0,1,2 respectively.
This change adds AH and FIZ to the list of bits that can be
dynamically modified on purpose (like rounding modes), and puts NEP
into a new category of 'must be 0'.

Rationale: NEP changes the _shape_ of the affected instructions, in the
sense that it makes them write different amounts of output, and depend
on different amounts of their input. So it's very unlikely that code
generation will be able to be NEP-agnostic: code written to assume
NEP=0 won't do anything useful if run with NEP=1 and vice versa.

But the other two flags change minor details of return values of
existing operations, and might be useful not only to code binary-
translated from an architecture with those details of behaviour, but
also to code recompiled from source, if the source was written in the
expectation of running on that architecture.

Change-Id: I2abe983eea85b402166697c084164a5049f42c77
Reviewed-on: https://eu-gerrit-1.euhpc.arm.com/c/dsg-spec/abi-aa/+/259687
Tested-by: Ties Stuij <ties.stuij@arm.com>
Reviewed-by: Ties Stuij <ties.stuij@arm.com>