### PR TITLE
Reserve relocation codes for PAuthABI

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1582,6 +1582,10 @@ Unallocated relocations
 
 All unallocated relocation types are reserved for use by future revisions of this specification.
 
+PAuthABI relocations
+^^^^^^^^^^^^^^^^^^^^
+
+The PAuthABI relocations are currently defined in the vendor experiment space. Arm reserves codes 580 to 600 for static PAuthABI relocations and 1040 - 1060 for dynamic PAuthABI relocations.
 
 Idempotency
 ^^^^^^^^^^^


### PR DESCRIPTION
The Alpha PAuthABI defines a small number of static and dynamic relocations
in the private vendor experiment space. When an upstream implementation
lands we will want to use non-experimental codes. Step 1 is to reserve
a range of static and dynamic relocations in AAELF64 so we can guarantee
no clash with any relocations defined in the PAuthABI.