### PR TITLE
sharpen up definition of the extent of the stack

### DIFF
--- a/aapcs32/aapcs32.rst
+++ b/aapcs32/aapcs32.rst
@@ -1044,7 +1044,7 @@ Universal stack constraints
 
 At all times the following basic constraints must hold:
 
-*  Stack-limit < SP ≤ stack-base. The stack pointer must lie within the
+*  Stack-limit ≤ SP ≤ stack-base. The stack pointer must lie within the
    extent of the stack.
 
 *  SP mod 4 = 0. The stack must at all times be aligned to a word boundary.

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -911,7 +911,7 @@ Universal stack constraints
 
 At all times the following basic constraints must hold:
 
-- Stack-limit < SP <= stack-base. The stack pointer must lie within the extent of the stack.
+- Stack-limit ≤ SP ≤ stack-base. The stack pointer must lie within the extent of the stack.
 
 - A process may only access (for reading or writing) the closed interval of the entire stack delimited by [SP, stack-base – 1].
 


### PR DESCRIPTION
Currently, the SP is specified to lie between stack-base inclusive, and
stack-limit exclusive. Having the stack-limit be exclusive to the stack pointer
is confusing at best, so for clarity this patch changes the definition to be
stack-limit inclusive.