### PR TITLE
aaelf64-morello: Minor typo fix

### DIFF
--- a/aaelf64-morello/aaelf64-morello.rst
+++ b/aaelf64-morello/aaelf64-morello.rst
@@ -456,7 +456,7 @@ The following nomenclature is used in the descriptions of relocation operations:
   addresses to be resolved at dynamic link time. The ``GOT`` and each entry in it
   must be aligned to the pointer-size.
 
-- ``GDAT(S+A)`` represents a pointer_sized entry in the ``GOT`` for address
+- ``GDAT(S+A)`` represents a pointer-sized entry in the ``GOT`` for address
   ``S+A``. The entry will be relocated at run time with relocation
   ``R_MORELLO_GLOB_DAT(S+A)``.
 


### PR DESCRIPTION
Fix typo in description of GDAT(S+A) relocation operation.