### PR TITLE
Soft-deprecate GNU_PROPERTY_AARCH64_FEATURE_1_PAC

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1700,10 +1700,11 @@ sections are compatible with Branch Target Identification mechanism. An
 executable or shared object with this bit set is required to generate
 `Custom PLTs`_ with BTI instruction.
 
-``GNU_PROPERTY_AARCH64_FEATURE_1_PAC`` This indicates that all executable
-sections have Return Address Signing enabled. An executable or shared object
-with this bit set can generate `Custom PLTs`_ with a PAC
-instruction.
+``GNU_PROPERTY_AARCH64_FEATURE_1_PAC`` This indicates that all
+executable sections have been protected with Return Address Signing.
+Its use is optional, meaning that an ELF file where this feature bit
+is unset can still have Return Address signing enabled in some or all
+its executable sections.
 
 Program Loading
 ---------------


### PR DESCRIPTION
Users should not rely on this property to enquire about the status
of the protection of an ELF file. If it is present, then yes, the
file has been protected. If it is not present, it can still have
been protected to some extent.

The comment on Custom PLT protection has also been removed. This
protection is seen as a separate feature to PAC-ret, since you could
ask the linker to generate protected PLTs regardless of the presence
of PAC-ret.