### PR TITLE
Use “thread” rather than “process”

### DIFF
--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -926,7 +926,7 @@ Memory and the Stack
 Memory addresses
 ^^^^^^^^^^^^^^^^
 
-The address space may consist of one or more disjoint regions. Regions
+The address space consists of one or more disjoint regions. Regions
 must not span address zero (although one region may start at zero).
 
 The use of tagged addressing is platform specific and does not apply to

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -898,10 +898,32 @@ registers, or if it is a function that returns results in such registers,
 it must ensure that p4-p15 are preserved across the call. In other cases
 it need not preserve any scalable predicate register contents.
 
-Processes, Memory and the Stack
--------------------------------
+Threads and processes
+---------------------
 
-The AAPCS64 applies to a single thread of execution or process (hereafter referred to as a process). A process has a program state defined by the underlying machine registers and the contents of the memory it can access. The memory a process can access, without causing a run-time fault, may vary during the execution of the process.
+The AAPCS64 applies to a single _`thread` of execution.  Each thread is in
+turn part of a _`process`.  A process might contain one thread or several
+threads.
+
+The exact definition of “thread” and “process” depends on the platform.
+If the platform is a traditional multi-threaded operating system,
+“thread” and “process” generally have their usual meaning for that
+operating system. If the platform supports multiple processes but has
+no separate concept of threads, “thread” is synonymous with “process”.
+If a platform has no concurrency or preemption then it will generally
+have a single “thread” and “process” that executes all instructions.
+
+Each thread has its own register state, defined by the contents of the
+underlying machine registers. A process has a program state defined by
+its threads' register states and by the contents of the memory that the
+process can access. The memory that a process can access, without causing
+a run-time fault, may vary during the execution of its threads.
+
+Memory and the Stack
+--------------------
+
+Categories of memory
+^^^^^^^^^^^^^^^^^^^^
 
 The memory of a process can normally be classified into five categories:
 
@@ -913,14 +935,24 @@ The memory of a process can normally be classified into five categories:
 
 - The heap.
 
-- The stack.
+- Stacks, with one stack for each thread.
 
-Writable static data may be further sub-divided into initialized, zero-initialized and uninitialized data. Except for the stack there is no requirement for each class of memory to occupy a single contiguous region of memory. A process must always have some code and a stack, but need not have any of the other categories of memory.
+Each category of memory can contain multiple individual regions.
+These individual regions do not need to be contiguous and regions of one
+memory class can be interspersed with regions of another memory class.
+
+Writable static data may be further sub-divided into initialized, zero-initialized and uninitialized data.
 
 The heap is an area (or areas) of memory that are managed by the process itself (for example, with the C malloc function). It is typically used for the creation of dynamic data objects.
 
-A conforming program must only execute instructions that are in areas of memory designated to contain code.
+Each individual stack must occupy a single, contiguous region of memory.
+However, as noted above, multiple stacks do not need to be organized
+contiguously.
 
+A process must always have access to code and stacks, but need not have
+access to any of the other categories of memory.
+
+A conforming program must only execute instructions that are in areas of memory designated to contain code.
 
 Memory addresses
 ^^^^^^^^^^^^^^^^
@@ -928,7 +960,6 @@ Memory addresses
 The address space may consist of one or more disjoint regions. No region may span address zero (although one region may start at zero).
 
 The use of tagged addressing is platform specific and does not apply to 32-bit pointers. When tagged addressing is disabled all 64 bits of an address are passed to the translation system. When tagged addressing is enabled, the top eight bits of an address are ignored for the purposes of address translation. See also `Pointers`_, above.
-
 
 The Stack
 ^^^^^^^^^
@@ -948,7 +979,7 @@ At all times the following basic constraints must hold:
 
 - Stack-limit ≤ SP ≤ stack-base. The stack pointer must lie within the extent of the stack.
 
-- A process may only access (for reading or writing) the closed interval of the entire stack delimited by [SP, stack-base – 1].
+- A conforming program may only access (for reading or writing) the closed interval of the entire stack delimited by [SP, stack-base – 1].
 
 - If MTE is enabled, then the tag stored in the stack pointer must match the tag set on the range SP - Stack-limit (i.e. the unallocated portion of the stack).
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -929,7 +929,7 @@ The address space may consist of one or more disjoint regions. No region
 may span address zero (although one region may start at zero).
 
 The use of tagged addressing is platform specific and does not apply to
-32-bit pointers. When tagged addressing is disabled all 64 bits of an
+32-bit pointers. When tagged addressing is disabled, all 64 bits of an
 address are passed to the translation system. When tagged addressing is
 enabled, the top eight bits of an address are ignored for the purposes
 of address translation. See also `Pointers`_, above.
@@ -953,16 +953,16 @@ Each category of memory can contain multiple individual regions.
 These individual regions do not need to be contiguous and regions of one
 memory class can be interspersed with regions of another memory class.
 
-Writable static data may be further sub-divided into initialized, zero-initialized and uninitialized data.
+Writable static data may be further sub-divided into initialized, zero-initialized, and uninitialized data.
 
-The heap is an area (or areas) of memory that are managed by the process itself (for example, with the C malloc function). It is typically used for the creation of dynamic data objects.
+The heap is an area (or areas) of memory that the process manages itself (for example, with the C malloc function). It is typically to create dynamic data objects.
 
 Each individual stack must occupy a single, contiguous region of memory.
 However, as noted above, multiple stacks do not need to be organized
 contiguously.
 
-A process must always have access to code and stacks, but need not have
-access to any of the other categories of memory.
+A process must always have access to code and stacks, but does not need
+to have access to any of the other categories of memory.
 
 A conforming program must only execute instructions that are in areas of memory designated to contain code.
 
@@ -982,12 +982,12 @@ The stack is defined in terms of three values:
 
 * the special-purpose register SP
 
-The SP moves from the base to the limit as the stack grows and from the
+The SP moves from the base to the limit as the stack grows, and from the
 limit to the base as the stack shrinks. In practice, an application might
 not be able to determine the value of either the base or the limit.
 
 In the description below, the base, limit and SP for a thread T are
-denoted T.base, T.limit and T.SP respectively.
+denoted T.base, T.limit, and T.SP respectively.
 
 The stack implementation is full-descending, so that for each thread T:
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -998,6 +998,10 @@ The stack implementation is full-descending, so that for each thread T:
   by the half-open interval [T.SP, T.base). The active region is empty
   when T.SP is equal to T.base.
 
+* The inactive region of T's stack is the area of memory denoted
+  by the half-open interval [T.limit, T.SP). The inactive region is empty
+  when T.SP is equal to T.limit.
+
 The stack may have a fixed size or be dynamically extendable (by adjusting the stack-limit downwards).
 
 The rules for maintenance of the stack are divided into two parts: a set of constraints that must be observed at all times, and an additional constraint that must be observed at a public interface.
@@ -1008,16 +1012,15 @@ Universal stack constraints
 At all times during the execution of a thread T, the following basic
 constraints must hold for its stack S:
 
-- T.limit ≤ T.SP ≤ T.base. T's stack pointer must lie within the memory
-  occupied by S.
+- T.limit ≤ T.SP ≤ T.base. T's stack pointer must lie within the extent
+  of the memory occupied by S.
 
 - A conforming program must not access (for reading or writing) the
-  inactive region of S, denoted by the half-open interval [T.limit, T.SP).
-  This is true regardless of whether the access is performed by T or by
-  some other thread.
+  inactive region of S. This is true regardless of whether the access
+  is performed by T or by some other thread.
 
 - If MTE is enabled, then the tag stored in T.SP must match the tag set
-  on the inactive region of S, defined in the same way as above.
+  on the inactive region of S.
 
 Additionally, at any point at which memory is accessed via SP, the hardware requires that
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -987,8 +987,8 @@ The SP moves from the base to the limit as the stack grows, and from the
 limit to the base as the stack shrinks. In practice, an application might
 not be able to determine the value of either the base or the limit.
 
-In the description below, the base, limit and SP for a thread T are
-denoted T.base, T.limit, and T.SP respectively.
+In the description below, the base, limit, and current stack extent
+for a thread T are denoted T.base, T.limit, and T.SP respectively.
 
 The stack implementation is full-descending, so that for each thread T:
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -905,13 +905,14 @@ The AAPCS64 applies to a single _`thread` of execution.  Each thread is in
 turn part of a _`process`.  A process might contain one thread or several
 threads.
 
-The exact definition of “thread” and “process” depends on the platform.
-If the platform is a traditional multi-threaded operating system,
-“thread” and “process” generally have their usual meaning for that
-operating system. If the platform supports multiple processes but has
-no separate concept of threads, “thread” is synonymous with “process”.
-If a platform has no concurrency or preemption then it will generally
-have a single “thread” and “process” that executes all instructions.
+The exact definitions of the terms “thread” and “process” depend on the
+platform. For example, if the platform is a traditional multi-threaded
+operating system, the terms generally have their usual meaning for
+that operating system. If the platform supports multiple processes
+but has no separate concept of threads, each process will have a single
+thread of execution. If a platform has no concurrency or preemption
+then there will be a single thread and process that executes all
+instructions.
 
 Each thread has its own register state, defined by the contents of the
 underlying machine registers. A process has a program state defined by
@@ -925,8 +926,8 @@ Memory and the Stack
 Memory addresses
 ^^^^^^^^^^^^^^^^
 
-The address space may consist of one or more disjoint regions. No region
-may span address zero (although one region may start at zero).
+The address space may consist of one or more disjoint regions. Regions
+must not span address zero (although one region may start at zero).
 
 The use of tagged addressing is platform specific and does not apply to
 32-bit pointers. When tagged addressing is disabled, all 64 bits of an
@@ -955,14 +956,14 @@ memory class can be interspersed with regions of another memory class.
 
 Writable static data may be further sub-divided into initialized, zero-initialized, and uninitialized data.
 
-The heap is an area (or areas) of memory that the process manages itself (for example, with the C malloc function). It is typically to create dynamic data objects.
+The heap is an area (or areas) of memory that the process manages itself (for example, with the C malloc function). It is typically used to create dynamic data objects.
 
 Each individual stack must occupy a single, contiguous region of memory.
 However, as noted above, multiple stacks do not need to be organized
 contiguously.
 
-A process must always have access to code and stacks, but does not need
-to have access to any of the other categories of memory.
+A process must always have access to code and stacks, and it may have
+access to any of the other categories of memory.
 
 A conforming program must only execute instructions that are in areas of memory designated to contain code.
 
@@ -980,7 +981,7 @@ The stack is defined in terms of three values:
 
 * a limit
 
-* the special-purpose register SP
+* the current stack extent, stored in the special-purpose register SP
 
 The SP moves from the base to the limit as the stack grows, and from the
 limit to the base as the stack shrinks. In practice, an application might
@@ -1015,9 +1016,8 @@ constraints must hold for its stack S:
 - T.limit ≤ T.SP ≤ T.base. T's stack pointer must lie within the extent
   of the memory occupied by S.
 
-- A conforming program must not access (for reading or writing) the
-  inactive region of S. This is true regardless of whether the access
-  is performed by T or by some other thread.
+- No thread is permitted to access (for reading or for writing) the
+  inactive region of S.
 
 - If MTE is enabled, then the tag stored in T.SP must match the tag set
   on the inactive region of S.


### PR DESCRIPTION
The AAPCS64 uses “process” as a cover-all term for “thread
or process”:

  The AAPCS64 applies to a single thread of execution or
  process (hereafter referred to as a process).

However, SME adds a register called TPIDR2_EL0 that forms an
important part of the SME PCS.  The “T” in TPIDR2_EL0 stands
for “thread”, so it seemed incongruous to use “process” when
describing its role in the PCS.

This preliminary patch therefore tries to avoid treating
“thread” and “process” as synonymous.  Since the exact
nature of threads and processes depends on the platform,
the patch tries to give a flexible definition.

Two later parts of the PCS refer specifically to processes:

- “Universal stack constraints”, when describing the parts of stack
  memory that can be safely accessed.  These restrictions apply to
  the program generally (wrt a given thread's stack and SP), so the
  patch uses “conforming program” instead of “thread”.  This is also
  the term used in:

    A conforming program must only execute instructions that are in
    areas of memory designated to contain code.

- The section on interworking.  These restrictions specifically apply
  at the process level rather than just the thread level, so the patch
  leaves the wording unchanged.