### PR TITLE
Add alpha-level support for SME

### DIFF
--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -1528,7 +1528,7 @@ If a call to a subroutine S `returns normally`_, the call is said to
 “commit a lazy save” *for that particular return* if all the following
 conditions are true:
 
-* ZA is dormant on entry ot S, which implies that `TPIDR2_EL0`_ has
+* ZA is dormant on entry to S, which implies that `TPIDR2_EL0`_ has
   a nonzero value (“BLK”) on entry to S.
 
 * On return from S, all the following conditions are true:

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -695,6 +695,8 @@ The definitions are recursive; that is, each of the types may contain a Composit
    type i.e. before any alignment adjustment of the entire composite is
    applied
 
+.. _`aggregate`:
+
 Aggregates
 ^^^^^^^^^^
 


### PR DESCRIPTION
This patch adds support for SME (Scalable Matrix Extension).
At this stage it is still alpha quality.

The request also includes https://github.com/ARM-software/abi-aa/pull/122