### PR TITLE
compress when generating pdfs

### DIFF
--- a/tools/rst2pdf/generate-pdfs.sh
+++ b/tools/rst2pdf/generate-pdfs.sh
@@ -49,5 +49,6 @@ for doc in "${docs[@]}"; do
                        -s ${CURR_DIR}/rst2pdf-abi.style \
                        --repeat-table-rows              \
                        --default-dpi=110                \
+                       -c                               \
                        -o ${OUTPUT_DIR}/${doc}.pdf )
 done


### PR DESCRIPTION
This reduces the pdf size by more than 2 times:
    $ du -h pdfs*
    3.2M    pdfs
    7.5M    pdfs-old

This pull requests addresses/implements issue https://github.com/ARM-software/abi-aa/issues/119