### PR TITLE
for aapcs32 and aapcs64, link mention of language bindings

### DIFF
--- a/aapcs32/aapcs32.rst
+++ b/aapcs32/aapcs32.rst
@@ -749,7 +749,7 @@ following member may use the unallocated portion.  For the purposes of
 calculating the alignment of the aggregate the type of the member shall be
 the Fundamental Data Type upon which the bit-field is based. [#aapcs32-f4]_
 The layout of bit-fields within an aggregate is defined by the appropriate
-language binding.
+language binding (see `Arm C and C++ Language Mappings`_).
 
 Homogeneous Aggregates
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -703,7 +703,7 @@ Arrays
 Bit-fields subdivision
 ^^^^^^^^^^^^^^^^^^^^^^
 
-A member of an aggregate that is a Fundamental Data Type may be subdivided into bit-fields; if there are unused portions of such a member that are sufficient to start the following member at its Natural Alignment then the following member may use the unallocated portion. For the purposes of calculating the alignment of the aggregate the type of the member shall be the Fundamental Data Type upon which the bit-field is based [#aapcs64-f6]_. The layout of bit-fields within an aggregate is defined by the appropriate language binding.
+A member of an aggregate that is a Fundamental Data Type may be subdivided into bit-fields; if there are unused portions of such a member that are sufficient to start the following member at its Natural Alignment then the following member may use the unallocated portion. For the purposes of calculating the alignment of the aggregate the type of the member shall be the Fundamental Data Type upon which the bit-field is based [#aapcs64-f6]_. The layout of bit-fields within an aggregate is defined by the appropriate language binding (see `Arm C and C++ Language Mappings`_).
 
 Homogeneous Aggregates
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
In the bitfield section of these documents there is a mention of language
bindings, which is expounded upon in another section of those documents. To make
this clear and for quick referencing, links were added to the language binding
section.

This should address https://github.com/ARM-software/abi-aa/issues/126