### PR TITLE
Document new PT_AARCH64_MEMTAG_MTE segment

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1725,15 +1725,15 @@ p\_type
 
 .. table:: Processor-specific segment types
 
-    +-------------------------+-------------+------------------------------------------------------+
-    | Name                    | p\_type     | Meaning                                              |
-    +=========================+=============+======================================================+
-    | PT\_AARCH64\_ARCHEXT    | 0x70000000  | Reserved for architecture compatibility information  |
-    +-------------------------+-------------+------------------------------------------------------+
-    | PT\_AARCH64\_UNWIND     | 0x70000001  | Reserved for exception unwinding tables              |
-    +-------------------------+-------------+------------------------------------------------------+
-    | PT\_AARCH64\_MEMTAG_MTE | 0x70000002  | Reserved for MTE memory tag data dumps in core files |
-    +-------------------------+-------------+------------------------------------------------------+
+    +--------------------------+-------------+------------------------------------------------------+
+    | Name                     | p\_type     | Meaning                                              |
+    +==========================+=============+======================================================+
+    | PT\_AARCH64\_ARCHEXT     | 0x70000000  | Reserved for architecture compatibility information  |
+    +--------------------------+-------------+------------------------------------------------------+
+    | PT\_AARCH64\_UNWIND      | 0x70000001  | Reserved for exception unwinding tables              |
+    +--------------------------+-------------+------------------------------------------------------+
+    | PT\_AARCH64\_MEMTAG\_MTE | 0x70000002  | Reserved for MTE memory tag data dumps in core files |
+    +--------------------------+-------------+------------------------------------------------------+
 
 A segment of type ``PT_AARCH64_ARCHEXT`` (if present) contains information describing the architecture capabilities required by the executable file. Not all platform ABIs require this segment; the Linux ABI does not. If the segment is present it must appear before segment of type ``PT_LOAD``.
 

--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -262,27 +262,29 @@ This document refers to, or is referred to by, the following documents.
 
 .. table::
 
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | Ref                          | External reference or URL                                   | Title                                                       |
-  +==============================+=============================================================+=============================================================+
-  | AAELF64                      | Source for this document                                    | ELF for the Arm 64-bit Architecture (AArch64).              |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | AAPCS64_                     | IHI 0055                                                    | Procedure Call Standard for the Arm 64-bit Architecture     |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | Addenda32_                   | IHI 0045                                                    | Addenda to, and Errata in, the ABI for the Arm Architecture |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | PAuthABIELF64_               | pauthabielf64                                               | PAuth Extension to ELF for the Arm 64-bit Architecture      |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | LSB_                         | http://www.linuxbase.org/                                   | Linux Standards Base                                        |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | SCO-ELF_                     | http://www.sco.com/developers/gabi/                         | System V Application Binary Interface – DRAFT               |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | LINUX_ABI_                   | https://github.com/hjl-tools/linux-abi/wiki                 | Linux Extensions to gABI                                    |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | SYM-VER_                     | http://people.redhat.com/drepper/symbol-versioning          | GNU Symbol Versioning                                       |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
-  | TLSDESC_                     | http://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf | TLS Descriptors for Arm. Original proposal document         |
-  +------------------------------+-------------------------------------------------------------+-------------------------------------------------------------+
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | Ref                          | External reference or URL                                                                    | Title                                                       |
+  +==============================+==============================================================================================+=============================================================+
+  | AAELF64                      | Source for this document                                                                     | ELF for the Arm 64-bit Architecture (AArch64).              |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | AAPCS64_                     | IHI 0055                                                                                     | Procedure Call Standard for the Arm 64-bit Architecture     |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | Addenda32_                   | IHI 0045                                                                                     | Addenda to, and Errata in, the ABI for the Arm Architecture |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | PAuthABIELF64_               | pauthabielf64                                                                                | PAuth Extension to ELF for the Arm 64-bit Architecture      |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | LSB_                         | http://www.linuxbase.org/                                                                    | Linux Standards Base                                        |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | SCO-ELF_                     | http://www.sco.com/developers/gabi/                                                          | System V Application Binary Interface – DRAFT               |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | LINUX_ABI_                   | https://github.com/hjl-tools/linux-abi/wiki                                                  | Linux Extensions to gABI                                    |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | SYM-VER_                     | http://people.redhat.com/drepper/symbol-versioning                                           | GNU Symbol Versioning                                       |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | TLSDESC_                     | http://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf                                  | TLS Descriptors for Arm. Original proposal document         |
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  | MTEEXTENSIONS_               | https://www.kernel.org/doc/html/latest/arm64/memory-tagging-extension.html#core-dump-support | Linux Kernel MTE core dump format                           |
+  +------------------------------+-------------------------------------------------------------+----------------------------------------------------------------------------------------------+
 
 Terms and abbreviations
 -----------------------
@@ -1736,7 +1738,7 @@ A segment of type ``PT_AARCH64_ARCHEXT`` (if present) contains information descr
 
 ``PT_AARCH64_UNWIND`` (if present) describes the location of a program’s exception unwind tables.
 
-``PT_AARCH64_MEMTAG_MTE`` segments (if present) hold MTE memory tags for a particular memory range. The data is packed as 2 MTE tags per byte. There can be multiple ``PT_AARCH64_MEMTAG_MTE`` segments in a core file.
+``PT_AARCH64_MEMTAG_MTE`` segments (if present) hold MTE memory tags for a particular memory range. At present they are defined for core dump files of type ET_CORE. A description of the program header and contents can be found in [MTEEXTENSIONS_].
 
 p\_flags
   There are no AArch64-specific flags.

--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -284,7 +284,7 @@ This document refers to, or is referred to by, the following documents.
   | TLSDESC_                     | http://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf                                  | TLS Descriptors for Arm. Original proposal document         |
   +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
   | MTEEXTENSIONS_               | https://www.kernel.org/doc/html/latest/arm64/memory-tagging-extension.html#core-dump-support | Linux Kernel MTE core dump format                           |
-  +------------------------------+-------------------------------------------------------------+----------------------------------------------------------------------------------------------+
+  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
 
 Terms and abbreviations
 -----------------------

--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1722,17 +1722,21 @@ p\_type
 
 .. table:: Processor-specific segment types
 
-    +-----------------------+-------------+------------------------------------------------------+
-    | Name                  | p\_type     | Meaning                                              |
-    +=======================+=============+======================================================+
-    | PT\_AARCH64\_ARCHEXT  | 0x70000000  | Reserved for architecture compatibility information  |
-    +-----------------------+-------------+------------------------------------------------------+
-    | PT\_AARCH64\_UNWIND   | 0x70000001  | Reserved for exception unwinding tables              |
-    +-----------------------+-------------+------------------------------------------------------+
+    +-------------------------+-------------+------------------------------------------------------+
+    | Name                    | p\_type     | Meaning                                              |
+    +=========================+=============+======================================================+
+    | PT\_AARCH64\_ARCHEXT    | 0x70000000  | Reserved for architecture compatibility information  |
+    +-------------------------+-------------+------------------------------------------------------+
+    | PT\_AARCH64\_UNWIND     | 0x70000001  | Reserved for exception unwinding tables              |
+    +-------------------------+-------------+------------------------------------------------------+
+    | PT\_AARCH64\_MEMTAG_MTE | 0x70000002  | Reserved for MTE memory tag data dumps in core files |
+    +-------------------------+-------------+------------------------------------------------------+
 
 A segment of type ``PT_AARCH64_ARCHEXT`` (if present) contains information describing the architecture capabilities required by the executable file. Not all platform ABIs require this segment; the Linux ABI does not. If the segment is present it must appear before segment of type ``PT_LOAD``.
 
 ``PT_AARCH64_UNWIND`` (if present) describes the location of a program’s exception unwind tables.
+
+``PT_AARCH64_MEMTAG_MTE`` segments (if present) hold MTE memory tags for a particular memory range. The data is packed as 2 MTE tags per byte. There can be multiple ``PT_AARCH64_MEMTAG_MTE`` segments in a core file.
 
 p\_flags
   There are no AArch64-specific flags.

--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -17,6 +17,7 @@
 .. _LSB: http://www.linuxbase.org/
 .. _SYM-VER: http://www.akkadia.org/drepper/symbol-versioning
 .. _TLSDESC: http://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf
+.. _MTEEXTENSIONS: https://www.kernel.org/doc/html/latest/arm64/memory-tagging-extension.html#core-dump-support
 
 ELF for the Arm® 64-bit Architecture (AArch64)
 **********************************************


### PR DESCRIPTION
Add PT_AARCH64_MEMTAG_MTE to the table of AARCH64 segment types and document
its purpose.