### PR TITLE
Include the ABS64 and ABS32 relocations in Dynamic relocations

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1609,6 +1609,10 @@ The dynamic relocations for those execution environments that support only a lim
   +------------+------------+-------------------------+------------------------+-------------------------------------------+
   | ELF64 Code | ELF32 Code | Name                    | Operation              | Comment                                   |
   +============+============+=========================+========================+===========================================+
+  | 257        | \-         | R\_<CLS>\_ABS64         | S + A                  | See note below.                           |
+  +------------+------------+-------------------------+------------------------+-------------------------------------------+
+  | \-         | 1          | R\_<CLS>\_ABS32         | S + A                  | See note below.                           |
+  +------------+------------+-------------------------+------------------------+-------------------------------------------+
   | 1024       | 180        | R\_<CLS>\_COPY          |                        | See note below.                           |
   +------------+------------+-------------------------+------------------------+-------------------------------------------+
   | 1025       | 181        | R\_<CLS>\_GLOB\_DAT     | S + A                  | See note below                            |
@@ -1634,6 +1638,8 @@ The dynamic relocations for those execution environments that support only a lim
 
 
 With the exception of ``R_<CLS>_COPY`` all dynamic relocations require that the place being relocated is an 8-byte aligned 64-bit data location in ELF64 or a 4-byte aligned 32-bit data location in ELF32.
+
+``R_<CLS>_ABS64`` and ``R_<CLS>_ABS32`` may only appear in a well-formed executable or dynamic shared object in ELF64 or ELF32 respectively. Note that for their respective file format these relocations are both static and dynamic relocations.
 
 ``R_<CLS>_COPY`` may only appear in executable ELF files where e\_type is set to ``ET_EXEC``. The effect is to   cause the dynamic linker to locate the target symbol in a shared library object and then to copy the number of  bytes specified by its ``st_size`` field to the place. The address of the place is then used to pre-empt all other references to the specified symbol. It is an error if the storage space allocated in the executable is insufficient to hold the full copy of the symbol. If the object being copied contains dynamic relocations then the effect must be as if those relocations were performed before the copy was made.
 


### PR DESCRIPTION
These relocations are special since they are both dynamic and static
relocations.  At the start of the "Relocation" section (currently 5.7)
we state that "A well-formed executable file or dynamic shared object
has no static relocations after static linking".  At the moment there is
nothing in this document which mentions that the above relocations are
both dynamic and static, and hence it could be confusing to see such
relocations in an executable if just going based on the ABI
documentation.

This commit adds both relocations to the "Dynamic Relocations" table in
order to make the document self-consistent.  We also include a note
explaining that these relocations are special.

--- Explanation of some decisions:
In the dynamic relocations table I do not mention the ELF64 code for
ABS32 even though there is such a code.  This is because for ELF64 the
ABS32 relocation is not dynamic.

I include a comment about how these relocations are dynamic and static
for extra clarity, even though that is supposed to be implicit in the
fact that they occur in both tables.