### PR TITLE
Update rstcheck options for github CI

### DIFF
--- a/tools/common/check-rst-syntax.sh
+++ b/tools/common/check-rst-syntax.sh
@@ -38,5 +38,5 @@ declare -a docs=(
 )
 
 for doc in "${docs[@]}"; do
-    ( set -x; rstcheck --ignore-language=c,cpp --report=warning ${ABI_ROOT}/${doc}/${doc}.rst )
+    ( set -x; rstcheck --ignore-languages=c,cpp --report-level=warning ${ABI_ROOT}/${doc}/${doc}.rst )
 done


### PR DESCRIPTION
The current version of rstcheck (i.e. the version that the github CI
uses) does not have an option `--ignore-language` but instead has
`--ignore-languages`.

Without this update to our rst syntax checking script the github CI
fails on every PR.

N.b. The `rstcheck` change was here https://github.com/rstcheck/rstcheck/pull/100
N.b. I don't really know how to run the github actions CI on a PR change.
Hoping that this PR triggers it ;-)
E.g. https://github.com/ARM-software/abi-aa/pull/155