### PR TITLE
Fix formatting of v6 cell in core registers table

### DIFF
--- a/aapcs32/aapcs32.rst
+++ b/aapcs32/aapcs32.rst
@@ -819,11 +819,11 @@ one status register (CPSR) that is available for use in conforming code.
    +----------+---------+---------+-----------------------------------------+
    | r10      | v7      |         | Variable-register 7.                    |
    +----------+---------+---------+-----------------------------------------+
-   | r9       |         | v6      | Platform register.                      |
-   |          |         |         |                                         |
-   |          |         | SB      | The meaning of this register is defined |
-   |          |         |         | by the platform standard.               |
+   | r9       | v6      | SB      | Platform register or Variable-register  |
+   |          |         |         | 6.                                      |
    |          |         | TR      |                                         |
+   |          |         |         | The meaning of this register is defined |
+   |          |         |         | by the platform standard.               |
    +----------+---------+---------+-----------------------------------------+
    | r8       | v5      |         | Variable-register 5.                    |
    +----------+---------+---------+-----------------------------------------+


### PR DESCRIPTION
The alias `v6` was mistakenly in the `Special` column; I have moved it to `Synonym`. I have also included its other role in the `Role` column.