### PR TITLE
[Semihosting] Specify SYS_TIME return value as unsigned.

### DIFF
--- a/semihosting/semihosting.rst
+++ b/semihosting/semihosting.rst
@@ -1325,6 +1325,11 @@ Returns the number of seconds since 00:00 January 1, 1970.
 
 This value is real-world time, regardless of any debug agent configuration.
 
+The returned value should be interpreted as unsigned. There is no
+representation for times before 1970. On 32-bit implementations, this
+allows times after the year 2038 to be represented, by using values
+greater than `0x80000000`.
+
 Entry
 ^^^^^
 


### PR DESCRIPTION
In 32-bit semihosting, it was previously unclear whether a high-bit-set return value should be interpreted as a time before 1970 or after 2038. This change clarifies that it is the latter, which means that the semihosting API does not contain a year-2038 bug.

This is a safe change because SYS_TIME returns the _current_ time, and does not also need to deal with historic times (as the C <time.h> API does). Semihosting did not exist before 1970, so there will never have been any case in which SYS_TIME genuinely needed to return a value before 1970 as the current time.

The scope of this clarification is limited to the return value from SYS_TIME. It does not constrain the size of time_t used by C standard libraries, which are free to convert the unsigned 32-bit return value into a 64-bit signed value if that's the time_t type they want to use.

Of course, changing from a potentially signed 32-bit value to an unsigned one only postpones the year 2038 problem until 2106. If 32-bit semihosting is still around by then, it will need a new request to replace SYS_TIME.