### PR TITLE
Remove none from code-block:: in all rst documents

### DIFF
--- a/aadwarf32/aadwarf32.rst
+++ b/aadwarf32/aadwarf32.rst
@@ -615,7 +615,7 @@ To describe data that is explicitly declared big-endian or little-endian (by
 whatever means), use the DWARF 3.0 attribute ``DW_AT_endianity`` (0x65). It takes a
 single LEB128 constant argument value that is one of the following:
 
-.. code-block:: none
+.. code-block::
 
   DW_END_default (= 0)
   DW_END_big (= 1)		(Was 0 prior to the DWARF 3.0 standard)

--- a/aadwarf64-morello/aadwarf64-morello.rst
+++ b/aadwarf64-morello/aadwarf64-morello.rst
@@ -539,7 +539,7 @@ Capability pointer: C++ source
 
 Capability pointer: DWARF description
 
-.. code-block:: none
+.. code-block::
 
    1$: DW_TAG_base_type
            DW_AT_name("char")
@@ -577,7 +577,7 @@ Intcap types: C++ source
 
 Intcap types: DWARF description
 
-.. code-block:: none
+.. code-block::
 
    1$: DW_TAG_base_type
            DW_AT_name("__intcap_t")
@@ -621,7 +621,7 @@ Capability pointers: C++ source
 
 Capability pointers: DWARF Version 5 description
 
-.. code-block:: none
+.. code-block::
 
    ! *** Section .debug_abbrev content
    a$h: 1

--- a/aapcs32/aapcs32.rst
+++ b/aapcs32/aapcs32.rst
@@ -1176,7 +1176,7 @@ address is loaded back into the PC (see `Interworking`_).
 A subroutine call can be synthesized by any instruction sequence that has
 the effect:
 
-.. code-block:: none
+.. code-block::
 
       LR[31:1] ← return address
       LR[0]    ← code type at return address (0 Arm, 1 Thumb)

--- a/bpabi32/bpabi32.rst
+++ b/bpabi32/bpabi32.rst
@@ -2848,7 +2848,7 @@ All of this remapping and rebasing is straightforward. Constructing the GOT,
 PLTGOT, and their corresponding dynamic relocations is trickier and we
 sketch that here.
 
-.. code-block:: none
+.. code-block::
 
    for each PLTGOT-generating relocation Type[Place](Symbol) in increasing place order
        if (not exists GOT(Symbol)) {
@@ -2965,7 +2965,7 @@ Import data tables are a little trickier to construct.
   * The processing of dynamic relocations now reduces to something like
     the following.
 
-.. code-block:: none
+.. code-block::
 
    for each DLL imported from
        for each GOT-generating relocation Type[Place](Symbol)

--- a/clibabi32/clibabi32.rst
+++ b/clibabi32/clibabi32.rst
@@ -848,7 +848,7 @@ whole group become link-time constants when \_AEABI\_PORTABILITY\_LEVEL != 0.
 
 A general template for managing this is:
 
-.. code-block:: none
+.. code-block::
 
   #if _AEABI_PORTABILITY_LEVEL == 0
   #  define XXXX ....

--- a/ehabi32/ehabi32.rst
+++ b/ehabi32/ehabi32.rst
@@ -1924,7 +1924,7 @@ The C++ exception semantics library must define the following routines
 which are part of the C++ Standard Library but which require knowledge
 of the implementation:
 
-.. code-block:: none
+.. code-block::
 
   bool std::uncaught_exception(void)
   void std::terminate(void)
@@ -1943,7 +1943,7 @@ Compiler helper functions
 Compiled C++ application code calls the following generic routines to
 implement C++ exception handling semantics.
 
-.. code-block:: none
+.. code-block::
 
   void *__cxa_allocate_exception(size_t size);
   void __cxa_free_exception(void *p);
@@ -2334,7 +2334,7 @@ behavior might depend on whether an exception propagation is in progress
 std::uncaught\_exception – must be performed *before* the call to
 \_\_cxa\_begin\_catch, and the handler code will then be of the form:
 
-.. code-block:: none
+.. code-block::
 
   Save UCB pointer somewhere (and move it to r0 if not already there)
   BL __cxa_get_exception_ptr
@@ -2345,7 +2345,7 @@ std::uncaught\_exception – must be performed *before* the call to
 Constructions whose behavior is independent of whether an exception
 propagation is in progress can use the shorter sequence:
 
-.. code-block:: none
+.. code-block::
 
   Move UCB pointer to r0 if it is not already there
   BL __cxa_begin_catch

--- a/semihosting/semihosting.rst
+++ b/semihosting/semihosting.rst
@@ -414,7 +414,7 @@ Semihosting feature bit reporting sequence format
 
 Feature bits are reported using a sequence of bytes, which are accessed by using the `SYS_OPEN (0x01)`_ call with the special path name ``:semihosting-features``. The byte sequence has the following format:
 
-.. code-block:: none
+.. code-block::
 
   byte 0: SHFB_MAGIC_0 0x53
   byte 1: SHFB_MAGIC_1 0x48
@@ -474,7 +474,7 @@ Example pseudocode function for querying feature bits
 
 The following C-like pseudocode describes one possible simple implementation of a check for a specific feature bit:
 
-.. code-block:: none
+.. code-block::
 
     #define MAGICLEN 4
     bool sh_feature_supported(int bytenum, int bitnum)
@@ -945,7 +945,7 @@ Entry
 
 On entry, the PARAMETER REGISTER contains the address of a pointer to a four-field data block. The contents of the data block are filled by the function. The following C-like pseudocode describes the layout of the block:
 
-.. code-block:: none
+.. code-block::
 
     struct block {
         void* heap_base;


### PR DESCRIPTION
Avoids a warnings when generating html, yet has no effect on the Github display or the PDF.

https://github.com/ARM-software/abi-aa/issues/207