### PR TITLE
[AAELF64][SYSVABI64] Move dynamic linking contents to sysvabi64

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -18,6 +18,7 @@
 .. _SYM-VER: http://www.akkadia.org/drepper/symbol-versioning
 .. _TLSDESC: http://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf
 .. _MTEEXTENSIONS: https://www.kernel.org/doc/html/latest/arm64/memory-tagging-extension.html#core-dump-support
+.. _SYSVABI64: https://github.com/ARM-software/abi-aa/releases
 .. _VFABI64: https://github.com/ARM-software/abi-aa/releases
 
 ELF for the Arm® 64-bit Architecture (AArch64)
@@ -271,6 +272,11 @@ changes to the content of the document for that release.
   |               |                    | - In `Program Loading`_, Relax BTI PLT  |
   |               |                    |   requirement                           |
   +---------------+--------------------+-----------------------------------------+
+  | 2023Q4        | 24\ :sup:`th`      | - In `Program Property`_,               |
+  |               | October 2023       |   `Program Loading`_ and                |
+  |               |                    |   `Dynamic Linking`. Move description to|
+  |               |                    |   `SYSVABI64`_                          |
+  +---------------+--------------------+-----------------------------------------+
 
 References
 ----------
@@ -279,29 +285,31 @@ This document refers to, or is referred to by, the following documents.
 
 .. table::
 
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | Ref                          | External reference or URL                                                                    | Title                                                       |
-  +==============================+==============================================================================================+=============================================================+
-  | AAELF64                      | Source for this document                                                                     | ELF for the Arm 64-bit Architecture (AArch64).              |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | AAPCS64_                     | IHI 0055                                                                                     | Procedure Call Standard for the Arm 64-bit Architecture     |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | Addenda32_                   | IHI 0045                                                                                     | Addenda to, and Errata in, the ABI for the Arm Architecture |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | PAuthABIELF64_               | pauthabielf64                                                                                | PAuth Extension to ELF for the Arm 64-bit Architecture      |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | LSB_                         | http://www.linuxbase.org/                                                                    | Linux Standards Base                                        |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | SCO-ELF_                     | http://www.sco.com/developers/gabi/                                                          | System V Application Binary Interface – DRAFT               |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | LINUX_ABI_                   | https://github.com/hjl-tools/linux-abi/wiki                                                  | Linux Extensions to gABI                                    |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | SYM-VER_                     | http://people.redhat.com/drepper/symbol-versioning                                           | GNU Symbol Versioning                                       |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | TLSDESC_                     | http://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf                                  | TLS Descriptors for Arm. Original proposal document         |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
-  | MTEEXTENSIONS_               | https://www.kernel.org/doc/html/latest/arm64/memory-tagging-extension.html#core-dump-support | Linux Kernel MTE core dump format                           |
-  +------------------------------+----------------------------------------------------------------------------------------------+-------------------------------------------------------------+
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | Ref                          | External reference or URL                                                                    | Title                                                                       |
+  +==============================+==============================================================================================+=============================================================================+
+  | AAELF64                      | Source for this document                                                                     | ELF for the Arm 64-bit Architecture (AArch64).                              |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | AAPCS64_                     | IHI 0055                                                                                     | Procedure Call Standard for the Arm 64-bit Architecture                     |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | Addenda32_                   | IHI 0045                                                                                     | Addenda to, and Errata in, the ABI for the Arm Architecture                 |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | PAuthABIELF64_               | pauthabielf64                                                                                | PAuth Extension to ELF for the Arm 64-bit Architecture                      |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | LSB_                         | http://www.linuxbase.org/                                                                    | Linux Standards Base                                                        |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | SCO-ELF_                     | http://www.sco.com/developers/gabi/                                                          | System V Application Binary Interface – DRAFT                               |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | LINUX_ABI_                   | https://github.com/hjl-tools/linux-abi/wiki                                                  | Linux Extensions to gABI                                                    |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | SYM-VER_                     | http://people.redhat.com/drepper/symbol-versioning                                           | GNU Symbol Versioning                                                       |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | TLSDESC_                     | http://www.fsfla.org/~lxoliva/writeups/TLS/paper-lk2006.pdf                                  | TLS Descriptors for Arm. Original proposal document                         |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | MTEEXTENSIONS_               | https://www.kernel.org/doc/html/latest/arm64/memory-tagging-extension.html#core-dump-support | Linux Kernel MTE core dump format                                           |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
+  | SYSVABI64_                   | sysvabi64                                                                                    | System V Application Binary Interface (ABI) for the Arm 64-bit Architecture |
+  +------------------------------+----------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+
 
 Terms and abbreviations
 -----------------------
@@ -1826,116 +1834,27 @@ At this time this ABI specifies no generic platform architecture compatibility d
 Program Property
 ----------------
 
-The following processor-specific program property types [LINUX_ABI_] are
-defined:
-
-.. table:: Program Property Type
-
-    +-----------------------------------------+------------+
-    | Name                                    | Value      |
-    +=========================================+============+
-    | GNU\_PROPERTY\_AARCH64\_FEATURE\_1\_AND | 0xc0000000 |
-    +-----------------------------------------+------------+
-
-``GNU_PROPERTY_AARCH64_FEATURE_1_AND`` describes a set of processor features
-with which an ELF object or executable image is compatible, but does not
-require in order to execute correctly.  It has a single 32-bit value for the
-``pr_data`` field.  Each bit represents a separate feature.
-
-Static linkers processing ELF relocatable objects must set the feature bit in
-the output object or image only if all the input objects have the corresponding
-feature bit set. For each feature bit set in an ELF executable or shared library,
-a loader may enable the corresponding processor feature for that ELF file.
-
-The following bits are defined for GNU_PROPERTY_AARCH64_FEATURE_1_AND:
-
-.. table:: GNU_PROPERTY_AARCH64_FEATURE_1_AND Bit Flags
-
-    +-----------------------------------------+------------+
-    | Name                                    | Value      |
-    +=========================================+============+
-    | GNU\_PROPERTY\_AARCH64\_FEATURE\_1\_BTI | 1U << 0    |
-    +-----------------------------------------+------------+
-    | GNU\_PROPERTY\_AARCH64\_FEATURE\_1\_PAC | 1U << 1    |
-    +-----------------------------------------+------------+
-
-``GNU_PROPERTY_AARCH64_FEATURE_1_BTI`` This indicates that all executable
-sections are compatible with Branch Target Identification mechanism. An
-executable or shared object with this bit set is required to generate
-`Custom PLTs`_ with BTI instruction.
-
-``GNU_PROPERTY_AARCH64_FEATURE_1_PAC`` This indicates that all
-executable sections have been protected with Return Address Signing.
-Its use is optional, meaning that an ELF file where this feature bit
-is unset can still have Return Address signing enabled in some or all of
-its executable sections.
+The information on Program Property has been moved to [SYSVABI64_].
 
 Program Loading
 ---------------
 
-Process ``GNU_PROPERTY_AARCH64_FEATURE_1_BTI``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If Branch Target Identification mechanism is enabled on a processor then
-the Guard Page (GP) bit must be disabled on the memory image of loaded
-executable segments of executables and shared objects that do not have
-``GNU_PROPERTY_AARCH64_FEATURE_1_BTI`` set, before execution is transferred
-to them.
+The information on program loading has been moved to [SYSVABI64_].
 
 Dynamic Linking
 ---------------
 
+The information on Dynamic Linking has been moved to [SYSVABI64_].
+
+Dynamic Section
+---------------
+
+The information on the Dynamic Section has been moved to [SYSVABI64_].
+
 Custom PLTs
 ^^^^^^^^^^^^
 
-- To support Branch Target Identification mechanism, in the presence
-  of a ``GNU_PROPERTY_AARCH64_FEATURE_1_BTI`` all PLT entries
-  generated by the linker that can be called indirectly must have a
-  BTI instruction as the first instruction. The linker must add the
-  ``DT_AARCH64_BTI_PLT`` (`AArch64 specific dynamic array tags`_) tag
-  to the dynamic section.
-
-- To support Pointer Authentication, PLT entries generated
-  by the linker can have an authenticating instruction as the final
-  instruction before branching back. The linker must add the
-  ``DT_AARCH64_PAC_PLT`` (`AArch64 specific dynamic array tags`_) tag to the dynamic section.
-
-- If the linker generates custom PLT entries with both BTI and PAC
-  instructions, it must add both ``DT_AARCH64_BTI_PLT`` and
-  ``DT_AARCH64_PAC_PLT`` tags to the dynamic section.
-
-
-Dynamic Section
-^^^^^^^^^^^^^^^
-
-AArch64 specifies the following processor-specific dynamic array tags.
-
-.. _`AArch64 specific dynamic array tags`:
-
-.. table:: AArch64 specific dynamic array tags
-
-    +---------------------------+------------+--------+-------------------+-------------------+
-    | Name                      | Value      | d\_un  | Executable        | Shared Object     |
-    +===========================+============+========+===================+===================+
-    | DT\_AARCH64\_BTI\_PLT     | 0x70000001 | d\_val | Platform specific | Platform Specific |
-    +---------------------------+------------+--------+-------------------+-------------------+
-    | DT\_AARCH64\_PAC\_PLT     | 0x70000003 | d\_val | Platform specific | Platform Specific |
-    +---------------------------+------------+--------+-------------------+-------------------+
-    | DT\_AARCH64\_VARIANT\_PCS | 0x70000005 | d\_val | Platform specific | Platform Specific |
-    +---------------------------+------------+--------+-------------------+-------------------+
-
-``DT_AARCH64_BTI_PLT`` indicates PLTs enabled with Branch Target Identification
-mechanism.
-
-``DT_AARCH64_PAC_PLT`` indicates PLTs enabled with Pointer Authentication.
-
-The presence of both ``DT_AARCH64_BTI_PLT`` and ``DT_AARCH64_PAC_PLT``
-indicates PLTs enabled with both Branch Target Identification mechanism and
-Pointer Authentication.
-
-``DT_AARCH64_VARIANT_PCS`` must be present if there are ``R_<CLS>_JUMP_SLOT``
-relocations that reference symbols marked with the ``STO_AARCH64_VARIANT_PCS``
-flag set in their ``st_other`` field.
+The information on custom PLTs has been moved to [SYSVABI64_].
 
 .. raw:: pdf
 


### PR DESCRIPTION
The Elf for the Arm 64-bit Architecture (aaelf64) describes the processor specific parts of the ELF specification common to all ELF environments from a statically linked freestanding environment with no OS to a hosted environment that supports dynamic linking.

The dynamic linking parts that are specific to SystemV style operating environments such as Linux, and in particular the GNU properties which are based on a Linux ABI extension are better documented in the SystemV ABI for Arm 64-bit Architecture.