### PR TITLE
[sysvabi] Make hard-float a requirement for sysvabi

### DIFF
--- a/sysvabi64/sysvabi64.rst
+++ b/sysvabi64/sysvabi64.rst
@@ -210,6 +210,8 @@ Change History
  |            |                              |   used by `PAuthABIELF64`_ and                        |
  |            |                              |   `MemTagABIELF64`_.                                  |
  +------------+------------------------------+-------------------------------------------------------+
+ | 2025Q1     | 04\ :sup:`th` February 2025  | Require hard-float ABI for sysvabi platforms          |
+ +------------+------------------------------+-------------------------------------------------------+
 
 References
 ----------
@@ -373,6 +375,16 @@ AArch64 system.
 
 Low Level Information
 =====================
+
+Hardware Requirements
+---------------------
+
+The AArch64 System V ABI requires the presence of SIMD and FP registers.
+
+Procedure call standard requirements
+------------------------------------
+
+The AArch64 System V ABI uses The Base Procedure Call Standard from (AAPCS64_).
 
 Not available for this Alpha release.
 


### PR DESCRIPTION
The aapcs64 base procedure call standard requires floating point and simd registers. With the advent of a soft-float ABI for R-profile CPUs without floating point, we are making it explicit that platforms based on the System V ABI are required to use the base procedure call standard.

Soft-float pull request in https://github.com/ARM-software/abi-aa/pull/232