### PR TITLE
[aaelf32] Note that R_ARM_PREL31 can create veneers

### DIFF
--- a/aaelf32/aaelf32.rst
+++ b/aaelf32/aaelf32.rst
@@ -2231,8 +2231,8 @@ to effect the transition to Thumb state. Conditional function call instructions
 
 A linker may use a veneer (a sequence of instructions) to implement the
 relocated branch if the relocation is one of R_ARM_PC24, R_ARM_CALL,
-R_ARM_JUMP24, (or, in Thumb state, R_ARM_THM_CALL, R_ARM_THM_JUMP24, or
-R_ARM_THM_JUMP19) and:
+R_ARM_JUMP24, R_ARM_PREL31, (or, in Thumb state, R_ARM_THM_CALL,
+R_ARM_THM_JUMP24, or R_ARM_THM_JUMP19) and:
 
 * The target symbol has type STT_FUNC
 


### PR DESCRIPTION
Since https://reviews.llvm.org/D25721, LLD has assumed this. I assume
other linkers behave similarly, and LLVM's ARM backend also assumes that
R_ARM_PREL31 is PLT-generating. Update the ABI to reflect that.
