### PR TITLE
[aaelf64] Fix equation for R_AARCH64_GOTPCREL32

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1262,7 +1262,7 @@ The following tables record single instruction relocations and relocations that 
   | 308        | \-         | R\_<CLS>\_GOTREL32   | S+A-GOT          | Write bits [31:0] of X at byte-aligned place P.  This represents a 32-bit offset relative to GOT, treated as signed;    |
   |            |            |                      |                  | Check that -2\ :sup:`31` <= X < 2\ :sup:`31`.                                                                           |
   +------------+------------+----------------------+------------------+-------------------------------------------------------------------------------------------------------------------------+
-  | 315        | \-         | R\_<CLS>\_GOTPCREL32 | G(GDAT(S+A))- P  | Write bits [31:0] of X at byte-aligned place P.  This represents a 32-bit offset relative to GOT entry for an address,  |
+  | 315        | \-         | R\_<CLS>\_GOTPCREL32 | G(GDAT(S))+A-P   | Write bits [31:0] of X at byte-aligned place P.  This represents a 32-bit offset relative to GOT entry for an address,  |
   |            |            |                      |                  | treated as signed; Check that -2\ :sup:`31` <= X < 2\ :sup:`31`.                                                        |
   +------------+------------+----------------------+------------------+-------------------------------------------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
The current wording for this reloc is `G(GDAT(S+A))-P` which means the addend is applied to the symbol we're taking the GOT entry for. What we actually want (and what's implemented in lld) is something similar to `R_X86_64_GOTPCREL` where the addend is applied to the location of the reloc rather than the symbol.