### PR TITLE
[pauthabielf64] Fix typo in relocation name

### DIFF
--- a/pauthabielf64/pauthabielf64.rst
+++ b/pauthabielf64/pauthabielf64.rst
@@ -1167,7 +1167,6 @@ The GOT entries must be relocated by AUTH variant dynamic relocations.
   |             |                                        |                                  | value to bits [11:0] of  |
   |             |                                        |                                  | X. No overflow check.    |
   +-------------+----------------------------------------+----------------------------------+--------------------------+
-
 .. raw:: pdf
 
    PageBreak
@@ -1181,7 +1180,9 @@ is the PAuth ABI equivalent of ``R_AARCH64_RELATIVE``. The underlying
 calculation performed by the dynamic linker is the same, the only
 difference is that the resulting pointer is signed. The dynamic linker
 reads the signing schema from the contents of the place of the dynamic
-relocation.
+relocation. The ``R_AARCH64_AUTH_GOT_ADD_LO12_NC`` relocation is an
+addition for the PAuth ABI and has no equivalent in (AAELF64_). It is
+used with the ``:got_auth_lo12:`` operator on an add instruction.
 
 .. table:: Additional AUTH Dynamic relocations
 

--- a/pauthabielf64/pauthabielf64.rst
+++ b/pauthabielf64/pauthabielf64.rst
@@ -1153,7 +1153,7 @@ The GOT entries must be relocated by AUTH variant dynamic relocations.
   |             |                                        |                                  | check that –2\ :sup:`32` |
   |             |                                        |                                  | <= X < 2\ :sup:`32`      |
   +-------------+----------------------------------------+----------------------------------+--------------------------+
-  | 0x811A      | R\_AARCH64\_AUTH\_GOT\_LO12_NC         | G(ENCD(GDAT(S + A)))             | Set the LD/ST immediate  |
+  | 0x811A      | R\_AARCH64\_AUTH\_LD64\_GOT\_LO12_NC   | G(ENCD(GDAT(S + A)))             | Set the LD/ST immediate  |
   |             |                                        |                                  | field to bits [11:3] of  |
   |             |                                        |                                  | X. No overflow check;    |
   |             |                                        |                                  | check that X&7 = 0       |


### PR DESCRIPTION
As pointed out in https://github.com/ARM-software/abi-aa/issues/253 the R_AARCH64_AUTH_GOT_LO12_NC is meant to be the AUTH variant of R_AARCH64_LD64_GOT_LO12_NC. As there is also a
R_AARCH64_LD32_GOT_LO12_NC relocation rename the relocation to R_AARCH64_LD64_AUTH_GOT_LO12_NC.

These relocations are in the appendix as we are currently expecting the GOT to be RELRO and unsigned in most signing schemas.