### PR TITLE
[SME] Add agnostic-ZA interface and routines to save/restore SME state

### DIFF
--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -2486,6 +2486,28 @@ enabled by PSTATE.ZA.
     ``PTR->ZT0`` are copied to ZT0.
 
 
+Dynamic symbols for supported state
+-----------------------------------
+
+A platform that supports SME may provide a set of dynamic symbols.
+
+The availability of these dynamic symbols indicates whether SME state is
+supported by the routines provided by the platform. These symbols
+can be used during dynamic linking to verify that SME state used in the
+program will be handled correctly by the runtime.
+
+This is particularly relevant for calls to `agnostic-ZA`_ functions, which
+can't make assumptions on PSTATE.ZA or what state is enabled by it. These
+functions rely on the routines defined in `SME support routines`_ to preserve
+all SME state that may be live in the caller. The level of support required
+by the program must therefore match the level of support provided by the
+runtime, which for dynamically linked executables can only be asserted
+during dynamic linking.
+
+* ``__arm_sme_routines_support_zt0`` is available when the SME support routines
+  support ZT0.
+
+
 Pseudo-code examples
 ====================
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -1754,7 +1754,6 @@ states of ZA on entry to a subroutine and the possible states of ZA on a
 .. _`private-ZA`:
 .. _`shared-ZA`:
 .. _`agnostic-ZA`:
-.. _`restore-ZA`:
 
 +-------------------+-------------------+---------------------------+
 | Type of interface | ZA state on entry | ZA state on normal return |

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -1386,6 +1386,8 @@ active
      would benefit from the lazy saving scheme.
 
 dormant
+   .. _`ZA dormant state`:
+
    All of the following are true:
 
    * PSTATE.ZA is 1
@@ -2361,9 +2363,8 @@ that is large enough to represent all state enabled by PSTATE.ZA.
 
 * The subroutine behaves as follows:
 
-  * If the current thread has access to FEAT_SME and PSTATE.ZA is 1,
-    X0 contains the total size required to save and restore all SME state
-    enabled by PSTATE.ZA.
+  * If ZA state is `active <ZA active state>`_, X0 contains the total size
+    required to save and restore all SME state enabled by PSTATE.ZA.
 
   * Otherwise, X0 contains a size large enough to represent internal state
     required for `__arm_sme_save`_ and `__arm_sme_restore`_.
@@ -2397,15 +2398,19 @@ by PSTATE.ZA.
 
 * The subroutine behaves as follows:
 
-  * If ``PTR`` does not point to a valid buffer with the required size, the
-    behavior of calling this subroutine is undefined.
+  * If ``PTR`` is not 16-byte aligned, the program aborts in some platform-
+    specific manner.
 
-  * If ZA state is 'active' on entry, then it is 'dormant' on normal return.
-    Otherwise the ZA state is unchanged.
+  * Otherwise if ``PTR`` does not point to a valid buffer with the required
+    size, the behavior of calling this subroutine is undefined.
+
+  * If ZA state is `active <ZA active state>`_ on entry, then it is
+    `dormant <ZA dormant state>`_ on normal return.  Otherwise the ZA state
+    is unchanged.
 
   * For the address ``PTR->VALID`` at an unspecified offset in the buffer,
     the value 0 is written to ``PTR->VALID`` and the subroutine returns, if
-    either of the following conditions is true:
+    one of the following conditions is true:
 
     * The current thread does not have access to SME.
 
@@ -2455,12 +2460,11 @@ enabled by PSTATE.ZA.
 
 * The subroutine behaves as follows:
 
-  * If ``PTR`` does not point to a valid buffer with the required size, the
-    behavior of calling this routine is undefined.
+  * If ``PTR`` is not 16-byte aligned, the program aborts in some platform-
+    specific manner.
 
-  * The ZA state on normal return is the same as the ZA state on entry to the
-    call to `__arm_sme_save`_ that was used to initialize the buffer
-    pointed to by ``PTR``.
+  * Otherwise if ``PTR`` does not point to a valid buffer with the required
+    size, the behavior of calling this subroutine is undefined.
 
   * For the address ``PTR->VALID`` at an unspecified offset in the buffer,
     if the value stored at address ``PTR->VALID`` is 0, then the subroutine
@@ -2471,7 +2475,7 @@ enabled by PSTATE.ZA.
 
     * The current thread does not have access to SME.
 
-    * ZA state is 'active' on entry.
+    * ZA state is `active <ZA active state>`_ on entry.
 
   * If PSTATE.ZA is 0, the subroutine enables PSTATE.ZA.
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -2391,7 +2391,7 @@ by PSTATE.ZA.
   PTR
     a 64-bit data pointer passed in X0 that points to a buffer which
     is guaranteed to have a size that is equal to or larger than the size
-    returned by `__arm_sme_state_size`_.
+    returned by `__arm_sme_state_size`_. The pointer must be 16-byte aligned.
 
 * The subroutine does not return a value.
 
@@ -2414,11 +2414,12 @@ by PSTATE.ZA.
     * TPIDR2_EL0 is not a NULL pointer.
 
   * For addresses ``PTR->BLK`` and ``PTR->ZA`` at unspecified offsets in
-    the buffer pointed to by ``PTR``, the address ``PTR->ZA`` is written to
-    ``PTR->BLK.za_save_buffer``, the streaming vector length in bytes
-    (``SVL.B``) is written to ``PTR->BLK.num_za_save_slices`` and the
-    address ``PTR->BLK`` is written to ``TPIDR2_EL0``, thus setting up a
-    lazy save.
+    the buffer pointed to by ``PTR``, the routine must set up a lazy save
+    by zero-initializing the TPIDR2 block at address ``PTR->BLK``, then
+    writing address ``PTR->ZA`` to ``PTR->BLK.za_save_buffer``, writing the
+    streaming vector length in bytes (``SVL.B``) to
+    ``PTR->BLK.num_za_save_slices`` and finally copying the address ``PTR->BLK``
+    to ``TPIDR2_EL0``.
 
   * If ZT0 is available, then for the address ``PTR->ZT0`` at an unspecified
     offset in the buffer pointed to by ``PTR``, the contents of ZT0 are written
@@ -2447,7 +2448,8 @@ enabled by PSTATE.ZA.
 
   PTR
     a 64-bit data pointer passed in X0 that points to a buffer that
-    is initialized by a call to `__arm_sme_save`_.
+    is initialized by a call to `__arm_sme_save`_. The pointer must be 16-byte
+    aligned.
 
 * The subroutine does not return a value.
 
@@ -2469,7 +2471,7 @@ enabled by PSTATE.ZA.
 
     * The current thread does not have access to SME.
 
-    * ZA state is active on entry.
+    * ZA state is 'active' on entry.
 
   * If PSTATE.ZA is 0, the subroutine enables PSTATE.ZA.
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -1364,6 +1364,8 @@ off
 active
    .. _`ZA active state`:
 
+   .. _`ZA state is active`:
+
    PSTATE.ZA is 1 and TPIDR2_EL0 is null.
 
    This state indicates that both of the following are true:
@@ -2356,14 +2358,14 @@ that is large enough to represent all state enabled by PSTATE.ZA.
   `__arm_sme_restore`_.
 
   The exact layout used to calculate the size is unspecified.  The
-  implementations of `__arm_sme_save`_ and `__arm_sme_restore`_ and
+  implementations of `__arm_sme_save`_, `__arm_sme_restore`_, and
   `__arm_sme_state_size`_ must all assume the same layout.
 
   The size is guaranteed to be a multiple of 16.
 
 * The subroutine behaves as follows:
 
-  * If ZA state is `active <ZA active state>`_, X0 contains the total size
+  * If the `ZA state is active`_, X0 contains the total size
     required to save and restore all SME state enabled by PSTATE.ZA.
 
   * Otherwise, X0 contains a size large enough to represent internal state
@@ -2404,9 +2406,8 @@ by PSTATE.ZA.
   * Otherwise if ``PTR`` does not point to a valid buffer with the required
     size, the behavior of calling this subroutine is undefined.
 
-  * If ZA state is `active <ZA active state>`_ on entry, then it is
-    `dormant <ZA dormant state>`_ on normal return.  Otherwise the ZA state
-    is unchanged.
+  * If the `ZA state is active`_ on entry, then it is dormant on normal return.
+    Otherwise the ZA state is unchanged.
 
   * For the address ``PTR->VALID`` at an unspecified offset in the buffer,
     the value 0 is written to ``PTR->VALID`` and the subroutine returns, if
@@ -2475,7 +2476,7 @@ enabled by PSTATE.ZA.
 
     * The current thread does not have access to SME.
 
-    * ZA state is `active <ZA active state>`_ on entry.
+    * The `ZA state is active`_ on entry.
 
   * If PSTATE.ZA is 0, the subroutine enables PSTATE.ZA.
 


### PR DESCRIPTION
This PR adds a new "agnostic-ZA" interface which is intended to be called from any subroutine without requiring a change to PSTATE.ZA. This PR also adds new SME ABI routines to save/restore state enabled by PSTATE.ZA.

The corresponding ACLE PR can be found [here](https://github.com/ARM-software/acle/pull/336).