### PR TITLE
Upgrade actions in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: install packages
@@ -18,7 +18,7 @@ jobs:
       run: tools/common/check-rst-syntax.sh
     - name: build PDFs
       run: tools/rst2pdf/generate-pdfs.sh PDFs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: PDFs
         path: PDFs


### PR DESCRIPTION
CI runs are failing because actions/upload-artifact@v2 has been deprecated: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Upgrade upload-artifact to v4 and upgrade the rest of the actions while at it too in order to avoid deprecation warnings.