### PR TITLE
Actions version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: install packages
@@ -18,7 +18,7 @@ jobs:
       run: tools/common/check-rst-syntax.sh
     - name: build PDFs
       run: tools/rst2pdf/generate-pdfs.sh PDFs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: PDFs
         path: PDFs


### PR DESCRIPTION
our GitHub action checks were failing because of update-artefact got depreciated.

While updating, I took the liberty to also update the other script versions:
- update checkout to v4, v2 is using a node that will soon be depreciated
- upload-artifact to v4, v2 has become depreciated
- update setup-python to v5, just to stay up-to-date