### PR TITLE
Include SME attributes in the name mangling of types

### DIFF
--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -256,6 +256,7 @@ changes to the content of the document for that release.
 |            | September 2024     | - Add soft-float PCS variant.                                    |
 |            |                    | - Add the __arm_get_current_vg SME support routine.              |
 |            |                    | - Clarify use of `it` when preserving z and p registers.         |
+|            |                    | - Update C++ mangling to include SME attributes in type names    |
 +------------+--------------------+------------------------------------------------------------------+
 
 References
@@ -3110,6 +3111,34 @@ instead.
 
 The SVE tuple types are mangled using their ``arm_sve.h`` names
 (``svBASExN_t``).
+
+Types which have an SME streaming or ZA interface should include an additional suffix as described in the table below:
+
++-------------------------+-----------------------------+
+| Type of interface       | Suffix                      |
++=========================+=============================+
+| Non-streaming (default) | None                        |
++-------------------------+-----------------------------+
+| Streaming               | sm                          |
++-------------------------+-----------------------------+
+| Streaming-compatible    | sc                          |
++-------------------------+-----------------------------+
+| Private-ZA (default)    | None                        |
++-------------------------+-----------------------------+
+| Shared-ZA               | sz                          |
++-------------------------+-----------------------------+
+
+A streaming interface suffix should precede any ZA interface suffix. For example:
+
+.. code:: c
+
+void f(svint8_t (*fn)() __arm_inout("za") __arm_streaming) { fn(); }
+
+is mangled as
+
+.. code:: c
+
+_Z1fPFu10__SVInt8_tsmszvE
 
 .. raw:: pdf
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -3132,13 +3132,13 @@ A streaming interface suffix should precede any ZA interface suffix. For example
 
 .. code:: c
 
-void f(svint8_t (*fn)() __arm_inout("za") __arm_streaming) { fn(); }
+   void f(svint8_t (*fn)() __arm_inout("za") __arm_streaming) { fn(); }
 
 is mangled as
 
 .. code:: c
 
-_Z1fPFu10__SVInt8_tsmszvE
+   _Z1fPFu10__SVInt8_tsmszvE
 
 .. raw:: pdf
 

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -3145,9 +3145,7 @@ where:
   +========================+==========================+
   | No ZA State (default)  | 0                        |
   +------------------------+--------------------------+
-  | Preserves ZA           | 1                        |
-  +------------------------+--------------------------+
-  | Shared ZA              | 2                        |
+  | Shared ZA              | 1                        |
   +------------------------+--------------------------+
 
 * zt0_state is an integer representing the ZT0 state of the function:
@@ -3157,9 +3155,7 @@ where:
   +========================+==========================+
   | No ZT0 State (default) | 0                        |
   +------------------------+--------------------------+
-  | Preserves ZT0          | 1                        |
-  +------------------------+--------------------------+
-  | Shared ZT0             | 2                        |
+  | Shared ZT0             | 1                        |
   +------------------------+--------------------------+
 
 For example:
@@ -3169,10 +3165,10 @@ For example:
   // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj1ELj0ELj0EE
   void f(svint8_t (*fn)() __arm_streaming) { fn(); }
 
-  // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj2ELj2ELj0EE
+  // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj2ELj1ELj0EE
   void f(svint8_t (*fn)() __arm_streaming_compatible __arm_inout("za")) { fn(); }
 
-  // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj0ELj0ELj2EE
+  // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj0ELj0ELj1EE
   void f(svint8_t (*fn)() __arm_in("zt0")) { fn(); }
 
 .. raw:: pdf

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -3162,13 +3162,13 @@ For example:
 
 .. code-block:: c++
 
-  // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj1ELj0ELj0EE
+  // Mangled as fP11__SME_ATTRSIFu10__SVInt8_tELj1ELj0ELj0EE
   void f(svint8_t (*fn)() __arm_streaming) { fn(); }
 
-  // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj2ELj1ELj0EE
+  // Mangled as fP11__SME_ATTRSIFu10__SVInt8_tELj2ELj1ELj0EE
   void f(svint8_t (*fn)() __arm_streaming_compatible __arm_inout("za")) { fn(); }
 
-  // Mangled as fP9__SME_ATTRSIFu10__SVInt8_tELj0ELj0ELj1EE
+  // Mangled as fP11__SME_ATTRSIFu10__SVInt8_tELj0ELj0ELj1EE
   void f(svint8_t (*fn)() __arm_in("zt0")) { fn(); }
 
 .. raw:: pdf


### PR DESCRIPTION
This change extends the name mangling of types to include the SME streaming
and ZA interface. This will avoid naming conflicts which can currently arise such
as in the following example:

```
  void foo(void (*f)()) { f(); }
  void foo(void (*f)() __arm_streaming) { f(); }
```

Without this change, both functions 'foo' above will mangle to the same
name, despite the function pointers being different.