### PR TITLE
Markup: fix two accidental triple-backticks.

### DIFF
--- a/dbgovl32/dbgovl32.rst
+++ b/dbgovl32/dbgovl32.rst
@@ -701,7 +701,7 @@ From an embedded perspective there are a number of issues with this.
 To integrate this mechanism in a manner more useful to embedded systems
 we propose the following.
 
--  Define a new ``.ARM.overlay_table``` section of type
+-  Define a new ``.ARM.overlay_table`` section of type
    ``SHT_ARM_OVERLAYSECTION`` = 0x70000005 with contents exactly as
    defined by [GNUOV_].
 

--- a/rtabi32/rtabi32.rst
+++ b/rtabi32/rtabi32.rst
@@ -727,7 +727,7 @@ causes a problem if the code uses FP values in its interface functions.
    might reasonably be offered in the base standard only with its
    FP-using functions declared in its supporting header files as
    base-standard interfaces using some Q-o-I means such as decoration
-   with ``__softfp``` or ``__ATTRIBUTE((softfp))__``.
+   with ``__softfp`` or ``__ATTRIBUTE((softfp))__``.
 
 The third use case causes a potential problem.
 


### PR DESCRIPTION
I noticed one of these in passing in RTABI32: Github's Markdown renderer showed a spurious backtick at the end of a sensible identifier in fixed-pitch text. Looking at the source, that's because the fixed-pitch section was closed by three backticks instead of the usual two.

Grepping the rest of the repository turned up one more case of the same thing, in DBGOVL32. This patch fixes both.