### PR TITLE
[AAPCS64] Clarify how __bf16 affects HFAs

### DIFF
--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -755,7 +755,7 @@ A member of an aggregate that is a Fundamental Data Type may be subdivided into 
 Homogeneous Aggregates
 ^^^^^^^^^^^^^^^^^^^^^^
 
-A Homogeneous Aggregate is a composite type where all of the Fundamental Data Types of the members that compose the type are the same. The test for homogeneity is applied after data layout is completed and without regard to access control or other source language restrictions. Note that for short-vector types the fundamental types are 64-bit vector and 128-bit vector; the type of the elements in the short vector does not form part of the test for homogeneity.
+A Homogeneous Aggregate is a composite type where all of the Fundamental Data Types of the members that compose the type are the same. The test for homogeneity is applied after data layout is completed and without regard to access control or other source language restrictions. Note that for short-vector types the fundamental types are 64-bit vector and 128-bit vector; the type of the elements in the short vector does not form part of the test for homogeneity. Likewise, the different half-precision floating point formats share a single Fundamental Data Type, so the format does not form part of the test for homogeneity.
 
 A Homogeneous Aggregate has a Base Type, which is the Fundamental Data Type of each Member. The overall size is the size of the Base Type multiplied by the number uniquely addressable Members; its alignment will be the alignment of the Base Type.
 
@@ -2740,11 +2740,11 @@ The mapping of C arithmetic types to Fundamental Data Types is shown in `Table 3
   +--------------------------------+-----------------------------------------+------------------------------------------------------------------------+
   | ``__uint128``                  | unsigned quad-word                      | Arm extension (used for LDXP/STXP)                                     |
   +--------------------------------+-----------------------------------------+------------------------------------------------------------------------+
-  | ``__fp16``                     | half precision (IEEE754-2008 format or  | Arm extension. See `Types Varying by Data Model`_                      |
-  |                                | Arm Alternative Format)                 |                                                                        |
+  | ``__fp16``                     | half precision                          | Arm extension. See `Types Varying by Data Model`_                      |
+  |                                |                                         | Using IEEE754-2008 format or Arm Alternative Format.                   |
   +--------------------------------+-----------------------------------------+------------------------------------------------------------------------+
-  | ``__bf16``                     | half precision Brain floating-point     | Arm extension.                                                         |
-  |                                | format                                  |                                                                        |
+  | ``__bf16``                     | half precision                          | Arm extension.                                                         |
+  |                                |                                         | Using Brain floating-point format.                                     |
   +--------------------------------+-----------------------------------------+------------------------------------------------------------------------+
   | ``float``                      | single precision (IEEE 754)             |                                                                        |
   +--------------------------------+-----------------------------------------+------------------------------------------------------------------------+


### PR DESCRIPTION
Currently, it's not completely clear whether a struct containing a mixture of different 16-bit floating point types is a Homogeneous Aggregate or not:

  struct foo {
    __fp16 a;
    __bf16 b;
  };

I think that the best interpretation of the current text is that this is an HFA, because there is only one entry in the "Fundamental Data Types" table, which is the only thing considered in the definition of a Homogeneous Aggregate.

However, the table in the "Mapping of C & C++ built-in data types" section used the formats in a column which otherwise contains Fundamental Data Types, which could be read to imply that the above struct is _not_ an HFA. I don't think this is correct, so I've moved the formats to the notes column, making it clear that the two source types map to the same Fundamental Data Type.

Current compiler behaviour:
* Clang considers this struct to be an HFA, matches the behaviour described in this ABI patch.
* GCC does not consider it to be an HFA, but it also does not think that a struct only containing __bf16 is an HFA either. That's unambiguously incorrect both before and after this patch, so it's just a special case of a broader GCC bug.