### PR TITLE
[AAELF64] BTI and veneers for bare-metal contexts.

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1354,6 +1354,7 @@ In some systems indirect calls may also use veneers in order to support dynamic 
 
 On platforms that do not support dynamic pre-emption of symbols, an unresolved weak reference to a symbol relocated by ``R_<CLS>_CALL26`` shall be treated as a jump to the next instruction (the call becomes a no-op). The behaviour of ``R_<CLS>_JUMP26`` and ``R_<CLS>_PLT32`` in these conditions is not specified by this standard.
 
+When a static linker uses an indirect branch in a veneer, it may not assume that a destination in the same link unit has a BTI instruction, or BTI compatible instruction, at the destination of the indirect branch. See `SYSVABI64`_ for additional requirements on code-generators and PLT sequences.
 
 Group relocations
 ^^^^^^^^^^^^^^^^^

--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -1365,7 +1365,7 @@ In some systems indirect calls may also use veneers in order to support dynamic 
 
 On platforms that do not support dynamic pre-emption of symbols, an unresolved weak reference to a symbol relocated by ``R_<CLS>_CALL26`` shall be treated as a jump to the next instruction (the call becomes a no-op). The behaviour of ``R_<CLS>_JUMP26`` and ``R_<CLS>_PLT32`` in these conditions is not specified by this standard.
 
-In a link-unit that is intended to be used when BTI guarded pages are enable, veneers created by the static linker that use an indirect branch must target a BTI instruction or a BTI compatible instruction. If the destination of the veneer is in the same link unit and does not have a BTI or BTI compatible instruction, the static linker must generate an additional veneer that has a BTI instruction followed by a transfer of control to the destination that does not use an indirect branch. See `SYSVABI64`_ for additional requirements on code-generators and PLT sequences.
+In a link-unit that is intended to be used when BTI guarded pages are enabled, veneers created by the static linker that use an indirect branch must target a BTI instruction or a BTI compatible instruction. If the destination of the veneer is in the same link unit and does not have a BTI or BTI compatible instruction, the static linker must generate an additional veneer that has a BTI instruction followed by a transfer of control to the destination that does not use an indirect branch. See `SYSVABI64`_ for additional requirements on code-generators and PLT sequences.
 
 Group relocations
 ^^^^^^^^^^^^^^^^^

--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -288,6 +288,10 @@ changes to the content of the document for that release.
   |               | April 2025         |   `SHF_AARCH64_PURECODE` processor      |
   |               |                    |   specific section attribute flag.      |
   +---------------+--------------------+-----------------------------------------+
+  | 2025Q2        | 9\ :sup:`th`       | - In `Call and Jump relocations`_ added |
+  |               | April 2025         |   static linker requirements on veneers |
+  |               |                    |   when BTI guarded pages are used.      |
+  +---------------+--------------------+-----------------------------------------+
 
 References
 ----------
@@ -357,6 +361,13 @@ ABI
 
 Arm-based
    ... based on the Arm architecture ...
+
+BTI
+   Branch Target Identification. A feature that allows memory pages
+   to be guarded against the execution of instructions that are not
+   the intended target of an indirect branch. An indirect branch from
+   a guarded page must land on a BTI instruction or an instruction
+   that has implicit BTI behavior.
 
 ELF32
    An ELF object file with a class of ELFCLASS32
@@ -1354,7 +1365,7 @@ In some systems indirect calls may also use veneers in order to support dynamic 
 
 On platforms that do not support dynamic pre-emption of symbols, an unresolved weak reference to a symbol relocated by ``R_<CLS>_CALL26`` shall be treated as a jump to the next instruction (the call becomes a no-op). The behaviour of ``R_<CLS>_JUMP26`` and ``R_<CLS>_PLT32`` in these conditions is not specified by this standard.
 
-When a static linker uses an indirect branch in a veneer, it may not assume that a destination in the same link unit has a BTI instruction, or BTI compatible instruction, at the destination of the indirect branch. See `SYSVABI64`_ for additional requirements on code-generators and PLT sequences.
+In a link-unit that is intended to be used when BTI guarded pages are enable, veneers created by the static linker that use an indirect branch must target a BTI instruction or a BTI compatible instruction. If the destination of the veneer is in the same link unit and does not have a BTI or BTI compatible instruction, the static linker must generate an additional veneer that has a BTI instruction followed by a transfer of control to the destination that does not use an indirect branch. See `SYSVABI64`_ for additional requirements on code-generators and PLT sequences.
 
 Group relocations
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Range extension veneers in a bare-metal context must not assume a BTI instruction is at the destination.

There is documentation in sysvabi64 that states this, but strictly speaking this need not apply to a bare-metal context. Document that linker generated veneers cannot assume a BTI for definitions in the same link unit.

Bare-metal systems do not support PLT or iPLT (ifunc) so the requirements surrounding code-generation can stay in the sysvabi64.