### PR TITLE
[SYSVABI] Add example that ifunc resolvers are indirectly called

### DIFF
--- a/sysvabi64/sysvabi64.rst
+++ b/sysvabi64/sysvabi64.rst
@@ -1715,7 +1715,9 @@ calls to that location.
   escapes to an entity that is permitted to generate an indirect
   branch that is opaque to the relocatable object producer. This
   includes the locations of all symbols that can be exported into the
-  dynamic symbol table by a static linker.
+  dynamic symbol table by a static linker. It also includes IFUNC
+  resolver functions as these are called indirectly via the dynamic
+  loader or a local relocation resolver when static linking.
 
 * A static linker is required to generate `Custom PLTs`_ with BTI
   instructions.


### PR DESCRIPTION
An ifunc resolver function needs a BTI as it is called indirectly via the dynamic loader when resolving the R_AARCH64_IRELATIVE relocation. When static linking the relocation is also resolved via an indirect branch to the resolver from a local resolver function like _dl_relocate_static_pie in glibc.