### PR TITLE
[AAELF64] Allow R_AARCH64_TLS_DTPREL to be used statically.

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -291,6 +291,8 @@ changes to the content of the document for that release.
   | 2025Q2        | 9\ :sup:`th`       | - In `Call and Jump relocations`_ added |
   |               | April 2025         |   static linker requirements on veneers |
   |               |                    |   when BTI guarded pages are used.      |
+  |               |                    | - R_AARCH64_TLS_DTPREL can be used as a |
+  |               |                    |   static relocation as well as dynamic  |
   +---------------+--------------------+-----------------------------------------+
 
 References
@@ -1724,6 +1726,27 @@ Thread-local storage descriptors
 
 Relocation codes ``R_<CLS>_TLSDESC_LDR``, ``R_<CLS>_TLSDESC_ADD`` and ``R_<CLS>_TLSDESC_CALL`` are needed to permit linker optimization of TLS descriptor code sequences to use Initial-exec or Local-exec TLS sequences; this can only be done if all relevant uses of TLS descriptors are marked to permit accurate relaxation. Object producers that are unable to satisfy this requirement must generate traditional General-dynamic TLS
 sequences using the relocations described in `General Dynamic thread-local storage model`_. The details of TLS descriptors are beyond the scope of this specification; a general introduction can be found in [TLSDESC_].
+
+Thread Local Storage Data Relocations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A data relocation is required to describe the location of a TLS variable in debug information.
+
+.. class:: aaelf64-tls-data-relocations
+
+.. table:: TLS data relocations
+
+  +------------+------------+-----------------------------+------------------------------------+-------------------------------------------+
+  | 1028       | 184        | R\_<CLS>\_TLS\_IMPDEF1      |                                    | See note below                            |
+  +------------+------------+-----------------------------+------------------------------------+-------------------------------------------+
+  | 1029       | 185        | R\_<CLS>\_TLS\_IMPDEF2      |                                    | See note below                            |
+  +------------+------------+-----------------------------+------------------------------------+-------------------------------------------+
+  |            |            | R\_<CLS>\_TLS\_DTPREL       | DTPREL(S+A)                        | See note below                            |
+  +------------+------------+-----------------------------+------------------------------------+-------------------------------------------+
+
+``R_<CLS>_TLS_DTPREL`` is both a static and dynamic relocation. When used as a static relocation ``S`` must be fully resolved at static link time to a symbol definition in the same module as the relocation.
+
+It is implementation defined whether ``R_<CLS>_TLS_IMPDEF1`` implements ``R_<CLS>_TLS_DTPREL`` and ``R_<CLS>_TLS_IMPDEF2`` implements ``R_<CLS>_TLS_DTPMOD`` or whether ``R_<CLS>_TLS_IMPDEF1`` implements ``R_<CLS>_TLS_DTPMOD`` and ``R_<CLS>_TLS_IMPDEF2`` implements ``R_<CLS>_TLS_DTPREL``; a platform must document its choice\ [#aaelf64-f1]_.
 
 Relocations for PAuth ABI Extension
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Permit the R_AARCH64_TLS_DTPREL dynamic relocation to be used statically so that debug information can describe the location of TLS variables.

All code sequences to access TLS data use immediates, hence all existing static TLS relocations are instruction relocations.

To describe the location of a TLS variable in debug information requires a static data relocation. The necessary expression needed is DTPREL(S + A) which is performed by the traditional dialect dynamic relocation R_AARCH64_TLS_DTPREL.

There is prior art in the x86_64 and PPC64 ABIs to use the equivalent relocation R_X86_64_DTPOFF64 and R_PPC_DTPREL64 respectively for relocating debug information statically.

The 32-bit Arm ABI uses the R_ARM_TLS_LDO32 static local dynamic relocation. The advantage of using local dynamic is that these only apply to a TLS variable local to the module so no additional note is needed. An alternative design adds a new relocation code to local dynamic.

fixes: https://github.com/ARM-software/abi-aa/issues/176

a static relocation with the necessary