### PR TITLE
[CI] Add roman to rst2pdf requirements.txt

### DIFF
--- a/tools/rst2pdf/requirements.txt
+++ b/tools/rst2pdf/requirements.txt
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 git+https://github.com/rst2pdf/rst2pdf@ed41beda8eae0239803d15dd2b829faef14c0160
+roman
 rstcheck
 matplotlib
 svglib


### PR DESCRIPTION
rst2pdf is falling over in CI with:
"ModuleNotFoundError: No module named 'roman'"
explicitly add roman to rst2pdf requirements.txt