### PR TITLE
[aaelf64] Clarify addend for R_AARCH64_GOTPCREL32

### DIFF
--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -294,6 +294,7 @@ changes to the content of the document for that release.
   |               |                    |   when BTI guarded pages are used.      |
   |               |                    | - Added section for structure protection|
   |               |                    |   extension relocations.                |
+  |               |                    | - R_AARCH64_GOTPCREL32, clarify addend  |
   +---------------+--------------------+-----------------------------------------+
 
 References
@@ -1316,7 +1317,7 @@ The following tables record single instruction relocations and relocations that 
   | 308        | \-         | R\_<CLS>\_GOTREL32   | S+A-GOT          | Write bits [31:0] of X at byte-aligned place P.  This represents a 32-bit offset relative to GOT, treated as signed;    |
   |            |            |                      |                  | Check that -2\ :sup:`31` <= X < 2\ :sup:`31`.                                                                           |
   +------------+------------+----------------------+------------------+-------------------------------------------------------------------------------------------------------------------------+
-  | 315        | \-         | R\_<CLS>\_GOTPCREL32 | G(GDAT(S))- P    | Write bits [31:0] of X at byte-aligned place P.  This represents a 32-bit offset relative to GOT entry for an address,  |
+  | 315        | \-         | R\_<CLS>\_GOTPCREL32 | G(GDAT(S))-P+A   | Write bits [31:0] of X at byte-aligned place P.  This represents a 32-bit offset relative to GOT entry for an address,  |
   |            |            |                      |                  | treated as signed; Check that -2\ :sup:`31` <= X < 2\ :sup:`31`.                                                        |
   +------------+------------+----------------------+------------------+-------------------------------------------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
Define the expression for R_AARCH64_GOTPCREL32 as GDAT(S)-P+A. This matches the only implementation in clang and lld.

The relocation is used to calculate the offset from the start of the vtable to a GOT entry that contains the address of the RTTI object. As the table entry for the RTTI pointer is at an offset from the start of the vtable the relocation addend contains -offset to cancel out.

Previously in https://github.com/ARM-software/abi-aa/pull/272 the relocation definition of relocations using GDAT(S+A) were changed to require A to be 0 as lld and GNU ld were implementing GDAT(S+A) as GDAT(S) + A and GDAT(S) + 0 respectively.

As this specific relocation is only implemented in clang and lld it is safe to update the description to match the implementation without affecting portability.

We use GDAT(S)-P+A rather than GDAT(S) + A - P as the latter implies that we are calculating an offset to a different GOT slot to GDAT(S) rather than an offset from P.

Discussion and example: https://github.com/ARM-software/abi-aa/pull/272