### PR TITLE
[sysvabi64] Code Models. Limit range to GOT to 2GiB

### DIFF
--- a/sysvabi64/sysvabi64.rst
+++ b/sysvabi64/sysvabi64.rst
@@ -701,7 +701,7 @@ along with the assumptions that the code model may make.
 .. table:: Code Models
 
   +--------+----------------+----------------+------------------------+
-  | Code   | Max text       | Max combined   | Additional GOT         |
+  | Code   | Max text       | Max combined   | Additional GOT size    |
   | Model  | segment size   | span of text   | restrictions           |
   |        |                | and data       |                        |
   |        |                | segments       |                        |
@@ -709,24 +709,15 @@ along with the assumptions that the code model may make.
   | tiny   | 1 MiB          | 1 Mib          | none                   |
   |        |                |                |                        |
   +--------+----------------+----------------+------------------------+
-  | small  | 2GiB           | 4 GiB          | max distance from text |
-  |        |                |                | to GOT < 2 GiB         |
-  |        |                |                +------------------------+
-  |        |                |                | pic: got size < 32 KiB |
+  | small  | 2GiB           | 4 GiB          | pic: got size < 32 KiB |
   |        |                |                +------------------------+
   |        |                |                | PIC: none              |
   +--------+----------------+----------------+------------------------+
-  | medium | 2GiB           | no restriction | max distance from text |
-  |        |                |                | to GOT < 2 GiB         |
-  |        |                |                +------------------------+
-  |        |                |                | pic: got size < 32 KiB |
+  | medium | 2GiB           | no restriction | pic: got size < 32 KiB |
   |        |                |                +------------------------+
   |        |                |                | PIC: none              |
   +--------+----------------+----------------+------------------------+
-  | large  | 2GiB           | no restriction | max distance from text |
-  |        |                |                | to GOT < 4 GiB         |
-  |        |                |                |                        |
-  |        |                |                |                        |
+  | large  | 2GiB           | no restriction | none                   |
   +--------+----------------+----------------+------------------------+
 
 .. note::
@@ -757,8 +748,8 @@ along with the assumptions that the code model may make.
   5. The text segment maximum size is limited to 2GiB by
   R_AARCH64_PLT32 relocations from ``.eh_frame`` sections.
 
-  6. The distance to the GOT in the small and medium code model is
-  limited to 2GiB by the R_AARCH64_GOTPCREL32 relocations.
+  6. The distance to the GOT from the text segment is limited to 2GiB
+  by the R_AARCH64_GOTPCREL32 relocations.
 
   7. While designing the code models it was estimated that only 2.6%
   of load modules (executables and dynamic shared objects) have a max

--- a/sysvabi64/sysvabi64.rst
+++ b/sysvabi64/sysvabi64.rst
@@ -216,6 +216,7 @@ Change History
  | 2025Q2     | 20\ :sup:`th` June     2024  | Require that ``PT_GNU_PROPERTY`` program header be    |
  |            |                              | present in executables and shared-libraries if a      |
  |            |                              | .note.gnu.property section is present.                |
+ |            |                              | - Update distance to GOT for small code-model         |
  +------------+------------------------------+-------------------------------------------------------+
 
 References
@@ -708,11 +709,17 @@ along with the assumptions that the code model may make.
   | tiny   | 1 MiB          | 1 Mib          | none                   |
   |        |                |                |                        |
   +--------+----------------+----------------+------------------------+
-  | small  | 2GiB           | 4 GiB          | pic: got size < 32 KiB |
+  | small  | 2GiB           | 4 GiB          | max distance from text |
+  |        |                |                | to GOT < 2 GiB         |
+  |        |                |                +------------------------+
+  |        |                |                | pic: got size < 32 KiB |
   |        |                |                +------------------------+
   |        |                |                | PIC: none              |
   +--------+----------------+----------------+------------------------+
-  | medium | 2GiB           | no restriction | pic: got size < 32 KiB |
+  | medium | 2GiB           | no restriction | max distance from text |
+  |        |                |                | to GOT < 2 GiB         |
+  |        |                |                +------------------------+
+  |        |                |                | pic: got size < 32 KiB |
   |        |                |                +------------------------+
   |        |                |                | PIC: none              |
   +--------+----------------+----------------+------------------------+
@@ -750,23 +757,26 @@ along with the assumptions that the code model may make.
   5. The text segment maximum size is limited to 2GiB by
   R_AARCH64_PLT32 relocations from ``.eh_frame`` sections.
 
-  6. While designing the code models it was estimated that only 2.6%
+  6. The distance to the GOT in the small and medium code model is
+  limited to 2GiB by the R_AARCH64_GOTPCREL32 relocations.
+
+  7. While designing the code models it was estimated that only 2.6%
   of load modules (executables and dynamic shared objects) have a max
   text segment size greater than 1MiB; the rest would all fit into the
   tiny model. However to avoid build option changes, it is recommended
   that the small model should be the default, with an explicit option
   to select the tiny model.
 
-  7. Executables and shared objects may be linked dynamically with other
+  8. Executables and shared objects may be linked dynamically with other
   shared objects which use a different code model.
 
-  8. Linking of relocatable objects of different code models is possible
+  9. Linking of relocatable objects of different code models is possible
   as is linking of PIC/PIE and non-PIC relocatable objects. The result
   of the combination is always the most limited model. For example the
   combination of a tiny code model PIC object and small code model
   non-PIC object is a tiny non-PIC executable.
 
-  9. The large code model is aimed at programs with large amounts of
+  10. The large code model is aimed at programs with large amounts of
   read-write data, not large amounts or sparsely placed code.
 
 Implementation of code models


### PR DESCRIPTION
The R_AARCH64_GOTPCREL32 relocation, currently used in clang when relative vtables are enabled, has a signed offset so is limited to 2 GiB range. This limits the range of GOT from the vtables to 2GiB.

Document this restriction in the tables for the small and medium code model. Add a note to explain the reason, so that if code generation does not use the relocation the distance to the GOT can be increased.

Fixes #343