### PR TITLE
[SYSVABIELF64] Remove ILP32 Support

### DIFF
--- a/sysvabi64/sysvabi64.rst
+++ b/sysvabi64/sysvabi64.rst
@@ -1169,7 +1169,7 @@ non-zero ``st_value``. A reference to this symbol will be resolved by
 the dynamic linker to the address PLT for the function in the
 executable.
 
-The ``R_<CLS>_JUMP_SLOT`` relocations defined in AAELF64_ are
+The ``R_AARCH64_JUMP_SLOT`` relocations defined in AAELF64_ are
 associated with PLT entries. These entries are used for direct
 function calls rather than for references to function addresses. These
 relocations do not use the special symbol value described
@@ -2070,7 +2070,7 @@ The presence of both ``DT_AARCH64_BTI_PLT`` and ``DT_AARCH64_PAC_PLT``
 indicates PLTs enabled with both Branch Target Identification mechanism and
 Pointer Authentication.
 
-``DT_AARCH64_VARIANT_PCS`` must be present if there are ``R_<CLS>_JUMP_SLOT``
+``DT_AARCH64_VARIANT_PCS`` must be present if there are ``R_AARCH64_JUMP_SLOT``
 relocations that reference symbols marked with the ``STO_AARCH64_VARIANT_PCS``
 flag set in their ``st_other`` field.
 


### PR DESCRIPTION
ILP32 support for ELF platforms in the documents has been in perpetual Beta, with new additions to the ABI not considering ILP32. Now that the one complete implementation in GCC has been deprecated (https://gcc.gnu.org/gcc-15/changes.html) we will be removing ILP32 from the ABI documentation.

Part of https://github.com/ARM-software/abi-aa/issues/369