### PR TITLE
Standardise on straight quotes in CC-BY-SA-4.0 notices. [NFC]

### DIFF
--- a/aadwarf32/TRADEMARK_NOTICE
+++ b/aadwarf32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aadwarf32/aadwarf32.rst
+++ b/aadwarf32/aadwarf32.rst
@@ -127,7 +127,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aadwarf64-morello/TRADEMARK_NOTICE
+++ b/aadwarf64-morello/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aadwarf64-morello/aadwarf64-morello.rst
+++ b/aadwarf64-morello/aadwarf64-morello.rst
@@ -128,7 +128,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aadwarf64/TRADEMARK_NOTICE
+++ b/aadwarf64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aadwarf64/aadwarf64.rst
+++ b/aadwarf64/aadwarf64.rst
@@ -124,7 +124,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aaelf32/TRADEMARK_NOTICE
+++ b/aaelf32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aaelf32/aaelf32.rst
+++ b/aaelf32/aaelf32.rst
@@ -140,7 +140,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aaelf64-morello/TRADEMARK_NOTICE
+++ b/aaelf64-morello/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aaelf64-morello/aaelf64-morello.rst
+++ b/aaelf64-morello/aaelf64-morello.rst
@@ -130,7 +130,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aaelf64/TRADEMARK_NOTICE
+++ b/aaelf64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aaelf64/aaelf64.rst
+++ b/aaelf64/aaelf64.rst
@@ -142,7 +142,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aapcs32/TRADEMARK_NOTICE
+++ b/aapcs32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aapcs32/aapcs32.rst
+++ b/aapcs32/aapcs32.rst
@@ -134,7 +134,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aapcs64-morello/TRADEMARK_NOTICE
+++ b/aapcs64-morello/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aapcs64-morello/aapcs64-morello.rst
+++ b/aapcs64-morello/aapcs64-morello.rst
@@ -122,7 +122,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aapcs64/TRADEMARK_NOTICE
+++ b/aapcs64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/aapcs64/aapcs64.rst
+++ b/aapcs64/aapcs64.rst
@@ -123,7 +123,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/addenda32/TRADEMARK_NOTICE
+++ b/addenda32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/addenda32/addenda32.rst
+++ b/addenda32/addenda32.rst
@@ -141,7 +141,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/advnote132/TRADEMARK_NOTICE
+++ b/advnote132/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/advnote132/advnote132.rst
+++ b/advnote132/advnote132.rst
@@ -142,7 +142,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/atomicsabi64/TRADEMARK_NOTICE
+++ b/atomicsabi64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/atomicsabi64/atomicsabi64.rst
+++ b/atomicsabi64/atomicsabi64.rst
@@ -147,7 +147,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/baabielf64/TRADEMARK_NOTICE
+++ b/baabielf64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/baabielf64/baabielf64.rst
+++ b/baabielf64/baabielf64.rst
@@ -122,7 +122,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/bpabi32/TRADEMARK_NOTICE
+++ b/bpabi32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/bpabi32/bpabi32.rst
+++ b/bpabi32/bpabi32.rst
@@ -140,7 +140,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/bsabi32/TRADEMARK_NOTICE
+++ b/bsabi32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/bsabi32/bsabi32.rst
+++ b/bsabi32/bsabi32.rst
@@ -147,7 +147,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/buildattr64/TRADEMARK_NOTICE
+++ b/buildattr64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/buildattr64/buildattr64.rst
+++ b/buildattr64/buildattr64.rst
@@ -137,7 +137,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/clibabi32/TRADEMARK_NOTICE
+++ b/clibabi32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/clibabi32/clibabi32.rst
+++ b/clibabi32/clibabi32.rst
@@ -133,7 +133,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/cppabi32/TRADEMARK_NOTICE
+++ b/cppabi32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/cppabi32/cppabi32.rst
+++ b/cppabi32/cppabi32.rst
@@ -153,7 +153,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/cppabi64/TRADEMARK_NOTICE
+++ b/cppabi64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/cppabi64/cppabi64.rst
+++ b/cppabi64/cppabi64.rst
@@ -147,7 +147,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/dbgovl32/TRADEMARK_NOTICE
+++ b/dbgovl32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/dbgovl32/dbgovl32.rst
+++ b/dbgovl32/dbgovl32.rst
@@ -134,7 +134,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/design-documents/buildattr64-rationale.rst
+++ b/design-documents/buildattr64-rationale.rst
@@ -81,7 +81,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/design-documents/elf64-loadable-unit-marking-rationale.rst
+++ b/design-documents/elf64-loadable-unit-marking-rationale.rst
@@ -85,7 +85,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/ehabi32/TRADEMARK_NOTICE
+++ b/ehabi32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/ehabi32/ehabi32.rst
+++ b/ehabi32/ehabi32.rst
@@ -128,7 +128,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/memtagabielf64/TRADEMARK_NOTICE
+++ b/memtagabielf64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/memtagabielf64/memtagabielf64.rst
+++ b/memtagabielf64/memtagabielf64.rst
@@ -138,7 +138,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/pauthabielf64/TRADEMARK_NOTICE
+++ b/pauthabielf64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/pauthabielf64/pauthabielf64.rst
+++ b/pauthabielf64/pauthabielf64.rst
@@ -140,7 +140,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/rtabi32/TRADEMARK_NOTICE
+++ b/rtabi32/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/rtabi32/rtabi32.rst
+++ b/rtabi32/rtabi32.rst
@@ -147,7 +147,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/semihosting/TRADEMARK_NOTICE
+++ b/semihosting/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/semihosting/semihosting.rst
+++ b/semihosting/semihosting.rst
@@ -127,7 +127,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/sysvabi64/TRADEMARK_NOTICE
+++ b/sysvabi64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/sysvabi64/sysvabi64.rst
+++ b/sysvabi64/sysvabi64.rst
@@ -140,7 +140,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/vfabia64/TRADEMARK_NOTICE
+++ b/vfabia64/TRADEMARK_NOTICE
@@ -1,6 +1,6 @@
 The text of and illustrations in this document are licensed
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit

--- a/vfabia64/vfabia64.rst
+++ b/vfabia64/vfabia64.rst
@@ -243,7 +243,7 @@ Trademark notice
 
 The text of and illustrations in this document are licensed by Arm
 under a Creative Commons Attribution–Share Alike 4.0 International
-license ("CC-BY-SA-4.0”), with an additional clause on patents.
+license ("CC-BY-SA-4.0"), with an additional clause on patents.
 The Arm trademarks featured here are registered trademarks or
 trademarks of Arm Limited (or its subsidiaries) in the US and/or
 elsewhere. All rights reserved. Please visit


### PR DESCRIPTION
The ABI and ACLE mix two different comment characters in several documents "CC-BY-SA-4.0”. Standardise on straight quotes "CC-BY-SA-4.0"